### PR TITLE
clean up tm2

### DIFF
--- a/gnovm/pkg/client/add.go
+++ b/gnovm/pkg/client/add.go
@@ -1,0 +1,308 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/bip39"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/crypto/multisig"
+)
+
+type addCfg struct {
+	rootCfg *baseCfg
+
+	multisig          commands.StringArr
+	multisigThreshold int
+	noSort            bool
+	publicKey         string
+	useLedger         bool
+	recover           bool
+	noBackup          bool
+	dryRun            bool
+	account           uint64
+	index             uint64
+}
+
+func newAddCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &addCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "add",
+			ShortUsage: "add [flags] <key-name>",
+			ShortHelp:  "Adds key to the keybase",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execAdd(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *addCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.Var(
+		&c.multisig,
+		"multisig",
+		"Construct and store a multisig public key (implies --pubkey)",
+	)
+
+	fs.IntVar(
+		&c.multisigThreshold,
+		"threshold",
+		1,
+		"K out of N required signatures. For use in conjunction with --multisig",
+	)
+
+	fs.BoolVar(
+		&c.noSort,
+		"nosort",
+		false,
+		"Keys passed to --multisig are taken in the order they're supplied",
+	)
+
+	fs.StringVar(
+		&c.publicKey,
+		"pubkey",
+		"",
+		"Parse a public key in bech32 format and save it to disk",
+	)
+
+	fs.BoolVar(
+		&c.useLedger,
+		"ledger",
+		false,
+		"Store a local reference to a private key on a Ledger device",
+	)
+
+	fs.BoolVar(
+		&c.recover,
+		"recover",
+		false,
+		"Provide seed phrase to recover existing key instead of creating",
+	)
+
+	fs.BoolVar(
+		&c.noBackup,
+		"nobackup",
+		false,
+		"Don't print out seed phrase (if others are watching the terminal)",
+	)
+
+	fs.BoolVar(
+		&c.dryRun,
+		"dryrun",
+		false,
+		"Perform action, but don't add key to local keystore",
+	)
+
+	fs.Uint64Var(
+		&c.account,
+		"account",
+		0,
+		"Account number for HD derivation",
+	)
+
+	fs.Uint64Var(
+		&c.index,
+		"index",
+		0,
+		"Address index number for HD derivation",
+	)
+}
+
+// DryRunKeyPass contains the default key password for genesis transactions
+const DryRunKeyPass = "12345678"
+
+/*
+input
+  - bip39 mnemonic
+  - bip39 passphrase
+  - bip44 path
+  - local encryption password
+
+output
+  - armor encrypted private key (saved to file)
+*/
+func execAdd(cfg *addCfg, args []string, io *commands.IO) error {
+	var (
+		kb              keys.Keybase
+		err             error
+		encryptPassword string
+	)
+
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	name := args[0]
+	showMnemonic := !cfg.noBackup
+
+	if cfg.dryRun {
+		// we throw this away, so don't enforce args,
+		// we want to get a new random seed phrase quickly
+		kb = keys.NewInMemory()
+		encryptPassword = DryRunKeyPass
+	} else {
+		kb, err = keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+		if err != nil {
+			return err
+		}
+
+		_, err = kb.GetByName(name)
+		if err == nil {
+			// account exists, ask for user confirmation
+			response, err2 := io.GetConfirmation(fmt.Sprintf("Override the existing name %s", name))
+			if err2 != nil {
+				return err2
+			}
+			if !response {
+				return errors.New("aborted")
+			}
+		}
+
+		multisigKeys := cfg.multisig
+		if len(multisigKeys) != 0 {
+			var pks []crypto.PubKey
+
+			multisigThreshold := cfg.multisigThreshold
+			if err := keys.ValidateMultisigThreshold(multisigThreshold, len(multisigKeys)); err != nil {
+				return err
+			}
+
+			for _, keyname := range multisigKeys {
+				k, err := kb.GetByName(keyname)
+				if err != nil {
+					return err
+				}
+				pks = append(pks, k.GetPubKey())
+			}
+
+			// Handle --nosort
+			if !cfg.noSort {
+				sort.Slice(pks, func(i, j int) bool {
+					return pks[i].Address().Compare(pks[j].Address()) < 0
+				})
+			}
+
+			pk := multisig.NewPubKeyMultisigThreshold(multisigThreshold, pks)
+			if _, err := kb.CreateMulti(name, pk); err != nil {
+				return err
+			}
+
+			io.Printfln("Key %q saved to disk.\n", name)
+			return nil
+		}
+
+		// ask for a password when generating a local key
+		if cfg.publicKey == "" && !cfg.useLedger {
+			encryptPassword, err = io.GetCheckPassword(
+				[2]string{
+					"Enter a passphrase to encrypt your key to disk:",
+					"Repeat the passphrase:",
+				},
+				cfg.rootCfg.InsecurePasswordStdin,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if cfg.publicKey != "" {
+		pk, err := crypto.PubKeyFromBech32(cfg.publicKey)
+		if err != nil {
+			return err
+		}
+		_, err = kb.CreateOffline(name, pk)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	account := cfg.account
+	index := cfg.index
+
+	// If we're using ledger, only thing we need is the path and the bech32 prefix.
+	if cfg.useLedger {
+		bech32PrefixAddr := crypto.Bech32AddrPrefix
+		info, err := kb.CreateLedger(name, keys.Secp256k1, bech32PrefixAddr, uint32(account), uint32(index))
+		if err != nil {
+			return err
+		}
+
+		return printCreate(info, false, "", io)
+	}
+
+	// Get bip39 mnemonic
+	var mnemonic string
+	const bip39Passphrase string = "" // XXX research.
+
+	if cfg.recover {
+		bip39Message := "Enter your bip39 mnemonic"
+		mnemonic, err = io.GetString(bip39Message)
+		if err != nil {
+			return err
+		}
+
+		if !bip39.IsMnemonicValid(mnemonic) {
+			return errors.New("invalid mnemonic")
+		}
+	}
+
+	if len(mnemonic) == 0 {
+		mnemonic, err = generateMnemonic(mnemonicEntropySize)
+		if err != nil {
+			return err
+		}
+	}
+
+	info, err := kb.CreateAccount(name, mnemonic, bip39Passphrase, encryptPassword, uint32(account), uint32(index))
+	if err != nil {
+		return err
+	}
+
+	// Recover key from seed passphrase
+	if cfg.recover {
+		// Hide mnemonic from output
+		showMnemonic = false
+		mnemonic = ""
+	}
+
+	return printCreate(info, showMnemonic, mnemonic, io)
+}
+
+func printCreate(info keys.Info, showMnemonic bool, mnemonic string, io *commands.IO) error {
+	io.Println("")
+	printNewInfo(info, io)
+
+	// print mnemonic unless requested not to.
+	if showMnemonic {
+		io.Printfln(`
+**IMPORTANT** write this mnemonic phrase in a safe place.
+It is the only way to recover your account if you ever forget your password.
+%v
+`, mnemonic)
+	}
+
+	return nil
+}
+
+func printNewInfo(info keys.Info, io *commands.IO) {
+	keyname := info.GetName()
+	keytype := info.GetType()
+	keypub := info.GetPubKey()
+	keyaddr := info.GetAddress()
+	keypath, _ := info.GetPath()
+
+	io.Printfln("* %s (%s) - addr: %v pub: %v, path: %v",
+		keyname, keytype, keyaddr, keypub, keypath)
+}

--- a/gnovm/pkg/client/add_test.go
+++ b/gnovm/pkg/client/add_test.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/crypto/secp256k1"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_execAddBasic(t *testing.T) {
+	t.Parallel()
+
+	// make new test dir
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	assert.NotNil(t, kbHome)
+	defer kbCleanUp()
+
+	cfg := &addCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				InsecurePasswordStdin: true,
+				Home:                  kbHome,
+			},
+		},
+	}
+
+	keyName := "keyname1"
+
+	io := commands.NewTestIO()
+	io.SetIn(strings.NewReader("test1234\ntest1234\n"))
+
+	// Create a new key
+	if err := execAdd(cfg, []string{keyName}, io); err != nil {
+		t.Fatalf("unable to execute add cmd, %v", err)
+	}
+
+	io.SetIn(strings.NewReader("y\ntest1234\ntest1234\n"))
+
+	// Confirm overwrite
+	if err := execAdd(cfg, []string{keyName}, io); err != nil {
+		t.Fatalf("unable to execute add cmd, %v", err)
+	}
+}
+
+var (
+	test2Mnemonic     = "hair stove window more scrap patient endorse left early pear lawn school loud divide vibrant family still bulk lyrics firm plate media critic dove"
+	test2PubkeyBech32 = "gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqg5y7u93gpzug38k2p8s8322zpdm96t0ch87ax88sre4vnclz2jcy8uyhst"
+)
+
+func Test_execAddPublicKey(t *testing.T) {
+	t.Parallel()
+
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	assert.NotNil(t, kbHome)
+	defer kbCleanUp()
+
+	cfg := &addCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home: kbHome,
+			},
+		},
+		publicKey: test2PubkeyBech32, // test2 account
+	}
+
+	if err := execAdd(cfg, []string{"test2"}, nil); err != nil {
+		t.Fatalf("unable to execute add cmd, %v", err)
+	}
+}
+
+func Test_execAddRecover(t *testing.T) {
+	t.Parallel()
+
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	assert.NotNil(t, kbHome)
+	defer kbCleanUp()
+
+	cfg := &addCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				InsecurePasswordStdin: true,
+				Home:                  kbHome,
+			},
+		},
+		recover: true, // init test2 account
+	}
+
+	test2Name := "test2"
+	test2Passphrase := "gn0rocks!"
+
+	io := commands.NewTestIO()
+	io.SetIn(strings.NewReader(test2Passphrase + "\n" + test2Passphrase + "\n" + test2Mnemonic + "\n"))
+
+	if err := execAdd(cfg, []string{test2Name}, io); err != nil {
+		t.Fatalf("unable to execute add cmd, %v", err)
+	}
+
+	kb, err2 := keys.NewKeyBaseFromDir(kbHome)
+	assert.NoError(t, err2)
+
+	infos, err3 := kb.List()
+	assert.NoError(t, err3)
+
+	info := infos[0]
+
+	keypub := info.GetPubKey()
+	keypub = keypub.(secp256k1.PubKeySecp256k1)
+
+	s := fmt.Sprintf("%s", keypub)
+	assert.Equal(t, s, test2PubkeyBech32)
+}

--- a/gnovm/pkg/client/addpkg.go
+++ b/gnovm/pkg/client/addpkg.go
@@ -1,0 +1,219 @@
+package client
+
+// TODO: move most of the logic in ROOT/gno.land/...
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/gnovm/pkg/vm" 
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type addPkgCfg struct {
+	rootCfg *makeTxCfg
+
+	pkgPath string
+	pkgDir  string
+	deposit string
+}
+
+func newAddPkgCmd(rootCfg *makeTxCfg) *commands.Command {
+	cfg := &addPkgCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "addpkg",
+			ShortUsage: "addpkg [flags] <key-name>",
+			ShortHelp:  "Uploads a new package",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execAddPkg(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *addPkgCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.pkgPath,
+		"pkgpath",
+		"",
+		"package path (required)",
+	)
+
+	fs.StringVar(
+		&c.pkgDir,
+		"pkgdir",
+		"",
+		"path to package files (required)",
+	)
+
+	fs.StringVar(
+		&c.deposit,
+		"deposit",
+		"",
+		"deposit coins",
+	)
+}
+
+func execAddPkg(cfg *addPkgCfg, args []string, io *commands.IO) error {
+	if cfg.pkgPath == "" {
+		return errors.New("pkgpath not specified")
+	}
+	if cfg.pkgDir == "" {
+		return errors.New("pkgdir not specified")
+	}
+
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	// read account pubkey.
+	nameOrBech32 := args[0]
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.rootCfg.Home)
+	if err != nil {
+		return err
+	}
+	info, err := kb.GetByNameOrAddress(nameOrBech32)
+	if err != nil {
+		return err
+	}
+	creator := info.GetAddress()
+	// info.GetPubKey()
+
+	// parse deposit.
+	deposit, err := std.ParseCoins(cfg.deposit)
+	if err != nil {
+		panic(err)
+	}
+
+	// open files in directory as MemPackage.
+	memPkg := gno.ReadMemPackage(cfg.pkgDir, cfg.pkgPath)
+
+	// precompile and validate syntax
+	err = gno.PrecompileAndCheckMempkg(memPkg)
+	if err != nil {
+		panic(err)
+	}
+
+	// parse gas wanted & fee.
+	gaswanted := cfg.rootCfg.gasWanted
+	gasfee, err := std.ParseCoin(cfg.rootCfg.gasFee)
+	if err != nil {
+		panic(err)
+	}
+	// construct msg & tx and marshal.
+	msg := vm.MsgAddPackage{
+		Creator: creator,
+		Package: memPkg,
+		Deposit: deposit,
+	}
+	tx := std.Tx{
+		Msgs:       []std.Msg{msg},
+		Fee:        std.NewFee(gaswanted, gasfee),
+		Signatures: nil,
+		Memo:       cfg.rootCfg.memo,
+	}
+
+	if cfg.rootCfg.broadcast {
+		err := signAndBroadcast(cfg.rootCfg, args, tx, io)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Println(string(amino.MustMarshalJSON(tx)))
+	}
+	return nil
+}
+
+func signAndBroadcast(
+	cfg *makeTxCfg,
+	args []string,
+	tx std.Tx,
+	io *commands.IO,
+) error {
+	baseopts := cfg.rootCfg
+	txopts := cfg
+
+	// query account
+	nameOrBech32 := args[0]
+	kb, err := keys.NewKeyBaseFromDir(baseopts.Home)
+	if err != nil {
+		return err
+	}
+	info, err := kb.GetByNameOrAddress(nameOrBech32)
+	if err != nil {
+		return err
+	}
+	accountAddr := info.GetAddress()
+
+	qopts := &queryCfg{
+		rootCfg: baseopts,
+		path:    fmt.Sprintf("auth/accounts/%s", accountAddr),
+	}
+	qres, err := queryHandler(qopts)
+	if err != nil {
+		return errors.Wrap(err, "query account")
+	}
+	var qret struct{ BaseAccount std.BaseAccount }
+	err = amino.UnmarshalJSON(qres.Response.Data, &qret)
+	if err != nil {
+		return err
+	}
+
+	// sign tx
+	accountNumber := qret.BaseAccount.AccountNumber
+	sequence := qret.BaseAccount.Sequence
+	sopts := &signCfg{
+		rootCfg:       baseopts,
+		sequence:      sequence,
+		accountNumber: accountNumber,
+		chainID:       txopts.chainID,
+		nameOrBech32:  nameOrBech32,
+		txJSON:        amino.MustMarshalJSON(tx),
+	}
+	if baseopts.Quiet {
+		sopts.pass, err = io.GetPassword("", baseopts.InsecurePasswordStdin)
+	} else {
+		sopts.pass, err = io.GetPassword("Enter password.", baseopts.InsecurePasswordStdin)
+	}
+	if err != nil {
+		return err
+	}
+
+	signedTx, err := SignHandler(sopts)
+	if err != nil {
+		return errors.Wrap(err, "sign tx")
+	}
+
+	// broadcast signed tx
+	bopts := &broadcastCfg{
+		rootCfg: baseopts,
+		tx:      signedTx,
+	}
+	bres, err := broadcastHandler(bopts)
+	if err != nil {
+		return errors.Wrap(err, "broadcast tx")
+	}
+	if bres.CheckTx.IsErr() {
+		return errors.Wrap(bres.CheckTx.Error, "check transaction failed: log:%s", bres.CheckTx.Log)
+	}
+	if bres.DeliverTx.IsErr() {
+		return errors.Wrap(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
+	}
+	io.Println(string(bres.DeliverTx.Data))
+	io.Println("OK!")
+	io.Println("GAS WANTED:", bres.DeliverTx.GasWanted)
+	io.Println("GAS USED:  ", bres.DeliverTx.GasUsed)
+
+	return nil
+}

--- a/gnovm/pkg/client/broadcast.go
+++ b/gnovm/pkg/client/broadcast.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type broadcastCfg struct {
+	rootCfg *baseCfg
+
+	dryRun bool
+
+	// internal
+	tx *std.Tx
+}
+
+func newBroadcastCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &broadcastCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "broadcast",
+			ShortUsage: "broadcast [flags] <file-name>",
+			ShortHelp:  "Broadcasts a signed document",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execBroadcast(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *broadcastCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.BoolVar(
+		&c.dryRun,
+		"dry-run",
+		false,
+		"perform a dry-run broadcast",
+	)
+}
+
+func execBroadcast(cfg *broadcastCfg, args []string, io *commands.IO) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+	filename := args[0]
+
+	jsonbz, err := os.ReadFile(filename)
+	if err != nil {
+		return errors.Wrap(err, "reading tx document file "+filename)
+	}
+	var tx std.Tx
+	err = amino.UnmarshalJSON(jsonbz, &tx)
+	if err != nil {
+		return errors.Wrap(err, "unmarshaling tx json bytes")
+	}
+	cfg.tx = &tx
+
+	res, err := broadcastHandler(cfg)
+	if err != nil {
+		return err
+	}
+
+	if res.CheckTx.IsErr() {
+		return errors.New("transaction failed %#v\nlog %s", res, res.CheckTx.Log)
+	} else if res.DeliverTx.IsErr() {
+		return errors.New("transaction failed %#v\nlog %s", res, res.DeliverTx.Log)
+	} else {
+		io.Println(string(res.DeliverTx.Data))
+		io.Println("OK!")
+		io.Println("GAS WANTED:", res.DeliverTx.GasWanted)
+		io.Println("GAS USED:  ", res.DeliverTx.GasUsed)
+	}
+	return nil
+}
+
+func broadcastHandler(cfg *broadcastCfg) (*ctypes.ResultBroadcastTxCommit, error) {
+	if cfg.tx == nil {
+		return nil, errors.New("invalid tx")
+	}
+
+	remote := cfg.rootCfg.Remote
+	if remote == "" || remote == "y" {
+		return nil, errors.New("missing remote url")
+	}
+
+	bz, err := amino.Marshal(cfg.tx)
+	if err != nil {
+		return nil, errors.Wrap(err, "remarshaling tx binary bytes")
+	}
+
+	cli := client.NewHTTP(remote, "/websocket")
+
+	if cfg.dryRun {
+		return simulateTx(cli, bz)
+	}
+
+	bres, err := cli.BroadcastTxCommit(bz)
+	if err != nil {
+		return nil, errors.Wrap(err, "broadcasting bytes")
+	}
+
+	return bres, nil
+}
+
+func simulateTx(cli client.ABCIClient, tx []byte) (*ctypes.ResultBroadcastTxCommit, error) {
+	bres, err := cli.ABCIQuery(".app/simulate", tx)
+	if err != nil {
+		return nil, errors.Wrap(err, "simulate tx")
+	}
+
+	var result abci.ResponseDeliverTx
+	err = amino.Unmarshal(bres.Response.Value, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling simulate result")
+	}
+
+	return &ctypes.ResultBroadcastTxCommit{
+		DeliverTx: result,
+	}, nil
+}

--- a/gnovm/pkg/client/call.go
+++ b/gnovm/pkg/client/call.go
@@ -1,0 +1,142 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/gnovm/pkg/vm" 
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type callCfg struct {
+	rootCfg *makeTxCfg
+
+	send     string
+	pkgPath  string
+	funcName string
+	args     commands.StringArr
+}
+
+func newCallCmd(rootCfg *makeTxCfg) *commands.Command {
+	cfg := &callCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "call",
+			ShortUsage: "call [flags] <key-name or address>",
+			ShortHelp:  "Executes a Realm function call",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execCall(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *callCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.send,
+		"send",
+		"",
+		"send amount",
+	)
+
+	fs.StringVar(
+		&c.pkgPath,
+		"pkgpath",
+		"",
+		"package path (required)",
+	)
+
+	fs.StringVar(
+		&c.funcName,
+		"func",
+		"",
+		"contract to call (required)",
+	)
+
+	fs.Var(
+		&c.args,
+		"args",
+		"arguments to contract",
+	)
+}
+
+func execCall(cfg *callCfg, args []string, io *commands.IO) error {
+	if cfg.pkgPath == "" {
+		return errors.New("pkgpath not specified")
+	}
+	if cfg.funcName == "" {
+		return errors.New("func not specified")
+	}
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+	if cfg.rootCfg.gasWanted == 0 {
+		return errors.New("gas-wanted not specified")
+	}
+	if cfg.rootCfg.gasFee == "" {
+		return errors.New("gas-fee not specified")
+	}
+
+	// read statement.
+	fnc := cfg.funcName
+
+	// read account pubkey.
+	nameOrBech32 := args[0]
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.rootCfg.Home)
+	if err != nil {
+		return err
+	}
+	info, err := kb.GetByNameOrAddress(nameOrBech32)
+	if err != nil {
+		return err
+	}
+	caller := info.GetAddress()
+	// info.GetPubKey()
+
+	// Parse send amount.
+	send, err := std.ParseCoins(cfg.send)
+	if err != nil {
+		return errors.Wrap(err, "parsing send coins")
+	}
+
+	// parse gas wanted & fee.
+	gaswanted := cfg.rootCfg.gasWanted
+	gasfee, err := std.ParseCoin(cfg.rootCfg.gasFee)
+	if err != nil {
+		return errors.Wrap(err, "parsing gas fee coin")
+	}
+
+	// construct msg & tx and marshal.
+	msg := vm.MsgCall{
+		Caller:  caller,
+		Send:    send,
+		PkgPath: cfg.pkgPath,
+		Func:    fnc,
+		Args:    cfg.args,
+	}
+	tx := std.Tx{
+		Msgs:       []std.Msg{msg},
+		Fee:        std.NewFee(gaswanted, gasfee),
+		Signatures: nil,
+		Memo:       cfg.rootCfg.memo,
+	}
+
+	if cfg.rootCfg.broadcast {
+		err := signAndBroadcast(cfg.rootCfg, args, tx, io)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Println(string(amino.MustMarshalJSON(tx)))
+	}
+	return nil
+}

--- a/gnovm/pkg/client/common.go
+++ b/gnovm/pkg/client/common.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type BaseOptions struct {
+	Home                  string
+	Remote                string
+	Quiet                 bool
+	InsecurePasswordStdin bool
+}
+
+var DefaultBaseOptions = BaseOptions{
+	Home:                  HomeDir(),
+	Remote:                "127.0.0.1:26657",
+	Quiet:                 false,
+	InsecurePasswordStdin: false,
+}
+
+func HomeDir() string {
+	// if environment set, always use that.
+	// if not, check whether can get os.UserHomeDir()
+	// if not, fall back to home directory
+	var err error
+	dir := os.Getenv("GNO_HOME")
+	if dir != "" {
+		return dir
+	}
+	dir, err = os.UserConfigDir()
+	if err == nil {
+		return filepath.Join(dir, "gno")
+	}
+	dir, err = os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(dir, ".gno")
+}

--- a/gnovm/pkg/client/delete.go
+++ b/gnovm/pkg/client/delete.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"flag"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+type deleteCfg struct {
+	rootCfg *baseCfg
+
+	yes   bool
+	force bool
+}
+
+func newDeleteCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &deleteCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "delete",
+			ShortUsage: "delete [flags] <key-name>",
+			ShortHelp:  "Deletes a key from the keybase",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execDelete(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *deleteCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.BoolVar(
+		&c.yes,
+		"yes",
+		false,
+		"skip confirmation prompt",
+	)
+
+	fs.BoolVar(
+		&c.force,
+		"force",
+		false,
+		"remove key unconditionally",
+	)
+}
+
+func execDelete(cfg *deleteCfg, args []string, io *commands.IO) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	nameOrBech32 := args[0]
+
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	if err != nil {
+		return err
+	}
+
+	info, err := kb.GetByNameOrAddress(nameOrBech32)
+	if err != nil {
+		return err
+	}
+
+	if info.GetType() == keys.TypeLedger || info.GetType() == keys.TypeOffline {
+		if !cfg.yes {
+			if err := confirmDeletion(io); err != nil {
+				return err
+			}
+		}
+
+		if err := kb.Delete(nameOrBech32, "", true); err != nil {
+			return err
+		}
+		io.ErrPrintln("Public key reference deleted")
+
+		return nil
+	}
+
+	// skip passphrase check if run with --force
+	skipPass := cfg.force
+	var oldpass string
+	if !skipPass {
+		msg := "DANGER - enter password to permanently delete key:"
+		if oldpass, err = io.GetPassword(msg, cfg.rootCfg.InsecurePasswordStdin); err != nil {
+			return err
+		}
+	}
+
+	err = kb.Delete(nameOrBech32, oldpass, skipPass)
+	if err != nil {
+		return err
+	}
+	io.ErrPrintln("Key deleted")
+
+	return nil
+}
+
+func confirmDeletion(io *commands.IO) error {
+	answer, err := io.GetConfirmation("Key reference will be deleted. Continue?")
+	if err != nil {
+		return err
+	}
+
+	if !answer {
+		return errors.New("aborted")
+	}
+
+	return nil
+}

--- a/gnovm/pkg/client/delete_test.go
+++ b/gnovm/pkg/client/delete_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testMnemonic = "equip will roof matter pink blind book anxiety banner elbow sun young"
+)
+
+func Test_execDelete(t *testing.T) {
+	t.Parallel()
+
+	// make new test dir
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	defer kbCleanUp()
+
+	// initialize test options
+	cfg := &deleteCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+	}
+
+	io := commands.NewTestIO()
+
+	fakeKeyName1 := "deleteApp_Key1"
+	fakeKeyName2 := "deleteApp_Key2"
+
+	// Add test accounts to keybase.
+	kb, err := keys.NewKeyBaseFromDir(kbHome)
+	assert.NoError(t, err)
+
+	_, err = kb.CreateAccount(fakeKeyName1, testMnemonic, "", "", 0, 0)
+	assert.NoError(t, err)
+
+	_, err = kb.CreateAccount(fakeKeyName2, testMnemonic, "", "", 0, 1)
+	assert.NoError(t, err)
+
+	// test: Key not found
+	args := []string{"blah"}
+	err = execDelete(cfg, args, nil)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Key blah not found")
+
+	// test: User confirmation missing
+	args = []string{fakeKeyName1}
+	io.SetIn(strings.NewReader(""))
+	err = execDelete(cfg, args, io)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "EOF")
+
+	{
+		_, err = kb.GetByName(fakeKeyName1)
+		require.NoError(t, err)
+
+		// Now there is a blank password followed by a confirmation.
+		args := []string{fakeKeyName1}
+		io.SetIn(strings.NewReader("\ny\n"))
+		err = execDelete(cfg, args, io)
+		require.NoError(t, err)
+
+		_, err = kb.GetByName(fakeKeyName1)
+		require.Error(t, err) // Key1 is gone
+	}
+
+	// Set config yes = true
+	cfg = &deleteCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+		yes: true,
+	}
+
+	_, err = kb.GetByName(fakeKeyName2)
+	require.NoError(t, err)
+
+	// Run again with blank password followed by eof.
+	args = []string{fakeKeyName2}
+	io.SetIn(strings.NewReader("\n"))
+	err = execDelete(cfg, args, io)
+	require.NoError(t, err)
+	_, err = kb.GetByName(fakeKeyName2)
+	require.Error(t, err) // Key2 is gone
+
+	// TODO: Write another case for !keys.Local
+}

--- a/gnovm/pkg/client/export.go
+++ b/gnovm/pkg/client/export.go
@@ -1,0 +1,142 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+type exportCfg struct {
+	rootCfg *baseCfg
+
+	nameOrBech32 string
+	outputPath   string
+	unsafe       bool
+}
+
+func newExportCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &exportCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "export",
+			ShortUsage: "export [flags]",
+			ShortHelp:  "Exports private key armor",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execExport(cfg, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *exportCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.nameOrBech32,
+		"key",
+		"",
+		"Name or Bech32 address of the private key",
+	)
+
+	fs.StringVar(
+		&c.outputPath,
+		"output-path",
+		"",
+		"The desired output path for the armor file",
+	)
+
+	fs.BoolVar(
+		&c.unsafe,
+		"unsafe",
+		false,
+		"Export the private key armor as unencrypted",
+	)
+}
+
+func execExport(cfg *exportCfg, io *commands.IO) error {
+	// Create a new instance of the key-base
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to create a key base from directory %s, %w",
+			cfg.rootCfg.Home,
+			err,
+		)
+	}
+
+	// Get the key-base decrypt password
+	decryptPassword, err := io.GetPassword(
+		"Enter a passphrase to decrypt your private key from disk:",
+		cfg.rootCfg.InsecurePasswordStdin,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve decrypt password from user, %w",
+			err,
+		)
+	}
+
+	var (
+		armor     string
+		exportErr error
+	)
+
+	if cfg.unsafe {
+		// Generate the unencrypted armor
+		armor, exportErr = kb.ExportPrivKeyUnsafe(
+			cfg.nameOrBech32,
+			decryptPassword,
+		)
+	} else {
+		// Get the armor encrypt password
+		encryptPassword, err := io.GetCheckPassword(
+			[2]string{
+				"Enter a passphrase to encrypt your private key armor:",
+				"Repeat the passphrase:",
+			},
+			cfg.rootCfg.InsecurePasswordStdin,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"unable to retrieve armor encrypt password from user, %w",
+				err,
+			)
+		}
+
+		// Generate the encrypted armor
+		armor, exportErr = kb.ExportPrivKey(
+			cfg.nameOrBech32,
+			decryptPassword,
+			encryptPassword,
+		)
+	}
+
+	if exportErr != nil {
+		return fmt.Errorf(
+			"unable to export the private key, %w",
+			exportErr,
+		)
+	}
+
+	// Write the armor to disk
+	if err := os.WriteFile(
+		cfg.outputPath,
+		[]byte(armor),
+		0o644,
+	); err != nil {
+		return fmt.Errorf(
+			"unable to write encrypted armor to file, %w",
+			err,
+		)
+	}
+
+	io.Printfln("Private key armor successfully outputted to %s", cfg.outputPath)
+
+	return nil
+}

--- a/gnovm/pkg/client/export_test.go
+++ b/gnovm/pkg/client/export_test.go
@@ -1,0 +1,206 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestKeybase generates a new test key-base
+// Returns the temporary key-base, and its path
+func newTestKeybase(t *testing.T) (keys.Keybase, string) {
+	t.Helper()
+
+	// Generate a temporary key-base directory
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+
+	t.Cleanup(func() {
+		kbCleanUp()
+	})
+
+	kb, err := keys.NewKeyBaseFromDir(kbHome)
+	if err != nil {
+		t.Fatalf(
+			"unable to create a key base in directory %s, %v",
+			kbHome,
+			err,
+		)
+	}
+
+	return kb, kbHome
+}
+
+// addRandomKeyToKeybase adds a random key to the key-base
+func addRandomKeyToKeybase(
+	kb keys.Keybase,
+	keyName,
+	encryptPassword string,
+) (keys.Info, error) {
+	// Generate a random mnemonic
+	mnemonic, err := generateMnemonic(mnemonicEntropySize)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to generate a mnemonic phrase, %w",
+			err,
+		)
+	}
+
+	// Add the key to the key base
+	return kb.CreateAccount(
+		keyName,
+		mnemonic,
+		"",
+		encryptPassword,
+		0,
+		0,
+	)
+}
+
+type testCmdKeyOptsBase struct {
+	kbHome          string
+	keyName         string
+	decryptPassword string
+	encryptPassword string
+	unsafe          bool
+}
+
+type testExportKeyOpts struct {
+	testCmdKeyOptsBase
+
+	outputPath string
+}
+
+// exportKey runs the private key export command
+// using the provided options
+func exportKey(
+	exportOpts testExportKeyOpts,
+	input io.Reader,
+) error {
+	cfg := &exportCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  exportOpts.kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+		nameOrBech32: exportOpts.keyName,
+		outputPath:   exportOpts.outputPath,
+		unsafe:       exportOpts.unsafe,
+	}
+
+	cmdIO := commands.NewTestIO()
+	cmdIO.SetIn(input)
+
+	return execExport(cfg, cmdIO)
+}
+
+// TestExport_ExportKey makes sure the key can be exported correctly
+func TestExport_ExportKey(t *testing.T) {
+	t.Parallel()
+
+	// numLines returns the number of new lines
+	// in a string
+	numLines := func(s string) int {
+		n := strings.Count(s, "\n")
+		if len(s) > 0 && !strings.HasSuffix(s, "\n") {
+			n++
+		}
+
+		return n
+	}
+
+	const (
+		keyName  = "key name"
+		password = "password"
+	)
+
+	testTable := []struct {
+		name     string
+		baseOpts testCmdKeyOptsBase
+		input    io.Reader
+	}{
+		{
+			"encrypted key export",
+			testCmdKeyOptsBase{},
+			strings.NewReader(
+				fmt.Sprintf(
+					"%s\n%s\n%s\n",
+					password, // decrypt
+					password, // encrypt
+					password, // encrypt confirm
+				),
+			),
+		},
+		{
+			"unencrypted key export",
+			testCmdKeyOptsBase{
+				unsafe: true,
+			},
+			strings.NewReader(
+				fmt.Sprintf(
+					"%s\n",
+					password, // decrypt
+				),
+			),
+		},
+	}
+
+	for _, testCase := range testTable {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a temporary key-base directory
+			kb, kbHome := newTestKeybase(t)
+
+			// Add an initial key to the key base
+			info, err := addRandomKeyToKeybase(kb, keyName, password)
+			if err != nil {
+				t.Fatalf(
+					"unable to create a key base account, %v",
+					err,
+				)
+			}
+
+			outputFile, outputCleanupFn := testutils.NewTestFile(t)
+			t.Cleanup(func() {
+				outputCleanupFn()
+			})
+
+			// Make sure the command executes correctly
+			assert.NoError(
+				t,
+				exportKey(
+					testExportKeyOpts{
+						testCmdKeyOptsBase: testCmdKeyOptsBase{
+							kbHome:  kbHome,
+							keyName: info.GetName(),
+							unsafe:  testCase.baseOpts.unsafe,
+						},
+						outputPath: outputFile.Name(),
+					},
+					testCase.input,
+				),
+			)
+
+			// Make sure the encrypted armor has been written to disk
+			buff, err := os.ReadFile(outputFile.Name())
+			if err != nil {
+				t.Fatalf(
+					"unable to read temporary file from disk, %v",
+					err,
+				)
+			}
+
+			assert.Greater(t, numLines(string(buff)), 1)
+		})
+	}
+}

--- a/gnovm/pkg/client/generate.go
+++ b/gnovm/pkg/client/generate.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/bip39"
+)
+
+type generateCfg struct {
+	rootCfg *baseCfg
+
+	customEntropy bool
+}
+
+func newGenerateCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &generateCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "generate",
+			ShortUsage: "generate [flags]",
+			ShortHelp:  "Generates a bip39 mnemonic",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execGenerate(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *generateCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.BoolVar(
+		&c.customEntropy,
+		"entropy",
+		false,
+		"supply custom entropy",
+	)
+}
+
+func execGenerate(cfg *generateCfg, args []string, io *commands.IO) error {
+	customEntropy := cfg.customEntropy
+
+	if len(args) != 0 {
+		return flag.ErrHelp
+	}
+
+	var entropySeed []byte
+
+	if customEntropy {
+		// prompt the user to enter some entropy
+		inputEntropy, err := io.GetString(
+			"WARNING: Generate at least 256-bits of entropy and enter the results here:",
+		)
+		if err != nil {
+			return err
+		}
+		if len(inputEntropy) < 43 {
+			return fmt.Errorf("256-bits is 43 characters in Base-64, and 100 in Base-6. You entered %v, and probably want more", len(inputEntropy))
+		}
+		conf, err := io.GetConfirmation(
+			fmt.Sprintf("Input length: %d", len(inputEntropy)),
+		)
+		if err != nil {
+			return err
+		}
+		if !conf {
+			return nil
+		}
+
+		// hash input entropy to get entropy seed
+		hashedEntropy := sha256.Sum256([]byte(inputEntropy))
+		entropySeed = hashedEntropy[:]
+	} else {
+		// read entropy seed straight from crypto.Rand
+		var err error
+		entropySeed, err = bip39.NewEntropy(mnemonicEntropySize)
+		if err != nil {
+			return err
+		}
+	}
+
+	mnemonic, err := bip39.NewMnemonic(entropySeed[:])
+	if err != nil {
+		return err
+	}
+
+	io.Println(mnemonic)
+
+	return nil
+}

--- a/gnovm/pkg/client/generate_test.go
+++ b/gnovm/pkg/client/generate_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_execGenerateNormal(t *testing.T) {
+	t.Parallel()
+
+	cfg := &generateCfg{
+		customEntropy: false,
+	}
+
+	err := execGenerate(cfg, []string{}, commands.NewTestIO())
+	require.NoError(t, err)
+}
+
+func Test_execGenerateUser(t *testing.T) {
+	t.Parallel()
+
+	cfg := &generateCfg{
+		customEntropy: true,
+	}
+
+	io := commands.NewTestIO()
+	io.SetIn(strings.NewReader(""))
+
+	err := execGenerate(cfg, []string{}, io)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "EOF")
+
+	// Try again
+	io.SetIn(strings.NewReader("Hi!\n"))
+	err = execGenerate(cfg, []string{}, io)
+	require.Error(t, err)
+	require.Equal(t, err.Error(),
+		"256-bits is 43 characters in Base-64, and 100 in Base-6. You entered 3, and probably want more")
+
+	// Now provide "good" entropy :)
+	fakeEntropy := strings.Repeat(":)", 40) + "\ny\n" // entropy + accept count
+	io.SetIn(strings.NewReader(fakeEntropy))
+	err = execGenerate(cfg, []string{}, io)
+	require.NoError(t, err)
+
+	// Now provide "good" entropy but no answer
+	fakeEntropy = strings.Repeat(":)", 40) + "\n" // entropy + accept count
+	io.SetIn(strings.NewReader(fakeEntropy))
+	err = execGenerate(cfg, []string{}, io)
+	require.Error(t, err)
+
+	// Now provide "good" entropy but say no
+	fakeEntropy = strings.Repeat(":)", 40) + "\nn\n" // entropy + accept count
+	io.SetIn(strings.NewReader(fakeEntropy))
+	err = execGenerate(cfg, []string{}, io)
+	require.NoError(t, err)
+}

--- a/gnovm/pkg/client/helper.go
+++ b/gnovm/pkg/client/helper.go
@@ -1,0 +1,16 @@
+package client
+
+import "github.com/gnolang/gno/tm2/pkg/crypto/bip39"
+
+// generateMnemonic generates a new BIP39 mnemonic using the
+// provided entropy size
+func generateMnemonic(entropySize int) (string, error) {
+	// Generate the entropy seed
+	entropySeed, err := bip39.NewEntropy(entropySize)
+	if err != nil {
+		return "", err
+	}
+
+	// Generate the actual mnemonic
+	return bip39.NewMnemonic(entropySeed[:])
+}

--- a/gnovm/pkg/client/import.go
+++ b/gnovm/pkg/client/import.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+type importCfg struct {
+	rootCfg *baseCfg
+
+	keyName   string
+	armorPath string
+	unsafe    bool
+}
+
+func newImportCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &importCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "import",
+			ShortUsage: "import [flags]",
+			ShortHelp:  "Imports encrypted private key armor",
+		},
+		cfg,
+		func(_ context.Context, _ []string) error {
+			return execImport(cfg, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *importCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.keyName,
+		"name",
+		"",
+		"The name of the private key",
+	)
+
+	fs.StringVar(
+		&c.armorPath,
+		"armor-path",
+		"",
+		"The path to the encrypted armor file",
+	)
+
+	fs.BoolVar(
+		&c.unsafe,
+		"unsafe",
+		false,
+		"Import the private key armor as unencrypted",
+	)
+}
+
+func execImport(cfg *importCfg, io *commands.IO) error {
+	// Create a new instance of the key-base
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to create a key base from directory %s, %w",
+			cfg.rootCfg.Home,
+			err,
+		)
+	}
+
+	// Read the raw encrypted armor
+	armor, err := os.ReadFile(cfg.armorPath)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to read armor from path %s, %w",
+			cfg.armorPath,
+			err,
+		)
+	}
+
+	var (
+		decryptPassword string
+		encryptPassword string
+	)
+
+	if !cfg.unsafe {
+		// Get the armor decrypt password
+		decryptPassword, err = io.GetPassword(
+			"Enter a passphrase to decrypt your private key armor:",
+			cfg.rootCfg.InsecurePasswordStdin,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"unable to retrieve armor decrypt password from user, %w",
+				err,
+			)
+		}
+	}
+
+	// Get the key-base encrypt password
+	encryptPassword, err = io.GetCheckPassword(
+		[2]string{
+			"Enter a passphrase to encrypt your private key:",
+			"Repeat the passphrase:",
+		},
+		cfg.rootCfg.InsecurePasswordStdin,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve key encrypt password from user, %w",
+			err,
+		)
+	}
+
+	if cfg.unsafe {
+		// Import the unencrypted private key
+		if err := kb.ImportPrivKeyUnsafe(
+			cfg.keyName,
+			string(armor),
+			encryptPassword,
+		); err != nil {
+			return fmt.Errorf(
+				"unable to import the unencrypted private key, %w",
+				err,
+			)
+		}
+	} else {
+		// Import the encrypted private key
+		if err := kb.ImportPrivKey(
+			cfg.keyName,
+			string(armor),
+			decryptPassword,
+			encryptPassword,
+		); err != nil {
+			return fmt.Errorf(
+				"unable to import the encrypted private key, %w",
+				err,
+			)
+		}
+	}
+
+	io.Printfln("Successfully imported private key %s", cfg.keyName)
+
+	return nil
+}

--- a/gnovm/pkg/client/import_test.go
+++ b/gnovm/pkg/client/import_test.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+type testImportKeyOpts struct {
+	testCmdKeyOptsBase
+
+	armorPath string
+}
+
+// importKey runs the import private key command (from armor)
+func importKey(
+	importOpts testImportKeyOpts,
+	input io.Reader,
+) error {
+	cfg := &importCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  importOpts.kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+		keyName:   importOpts.keyName,
+		armorPath: importOpts.armorPath,
+		unsafe:    importOpts.unsafe,
+	}
+
+	cmdIO := commands.NewTestIO()
+	cmdIO.SetIn(input)
+
+	return execImport(cfg, cmdIO)
+}
+
+// TestImport_ImportKey makes sure the key can be imported correctly
+func TestImport_ImportKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		keyName       = "key name"
+		importKeyName = "import key name"
+		password      = "password"
+	)
+
+	testTable := []struct {
+		name     string
+		baseOpts testCmdKeyOptsBase
+		input    io.Reader
+	}{
+		{
+			"encrypted private key",
+			testCmdKeyOptsBase{
+				unsafe: false, // explicit
+			},
+			strings.NewReader(
+				fmt.Sprintf(
+					"%s\n%s\n%s\n",
+					password, // decrypt
+					password, // key-base encrypt
+					password, // key-base encrypt confirm
+				),
+			),
+		},
+		{
+			"unencrypted private key",
+			testCmdKeyOptsBase{
+				unsafe: true,
+			},
+			strings.NewReader(
+				fmt.Sprintf(
+					"%s\n%s\n",
+					password, // key-base encrypt
+					password, // key-base encrypt confirm
+				),
+			),
+		},
+	}
+
+	for _, testCase := range testTable {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Generate a temporary key-base directory
+			kb, kbHome := newTestKeybase(t)
+
+			// Add an initial key to the key base
+			info, err := addRandomKeyToKeybase(kb, keyName, password)
+			if err != nil {
+				t.Fatalf(
+					"unable to create a key base account, %v",
+					err,
+				)
+			}
+
+			outputFile, outputCleanupFn := testutils.NewTestFile(t)
+			defer outputCleanupFn()
+
+			// Make sure the export command executes correctly
+			if err := exportKey(
+				testExportKeyOpts{
+					testCmdKeyOptsBase: testCmdKeyOptsBase{
+						kbHome:  kbHome,
+						keyName: keyName,
+						unsafe:  testCase.baseOpts.unsafe,
+					},
+					outputPath: outputFile.Name(),
+				},
+				strings.NewReader(
+					fmt.Sprintf(
+						"%s\n%s\n%s\n",
+						password,
+						password,
+						password,
+					),
+				),
+			); err != nil {
+				t.Fatalf("unable to export private key, %v", err)
+			}
+
+			// Make sure the encrypted armor can be imported correctly
+			if err := importKey(
+				testImportKeyOpts{
+					testCmdKeyOptsBase: testCmdKeyOptsBase{
+						kbHome: kbHome,
+						// Change the import key name so the existing one (in the key-base)
+						// doesn't get overwritten
+						keyName: importKeyName,
+						unsafe:  testCase.baseOpts.unsafe,
+					},
+					armorPath: outputFile.Name(),
+				},
+				testCase.input,
+			); err != nil {
+				t.Fatalf("unable to import private key armor, %v", err)
+			}
+
+			// Make sure the key-base has the new key imported
+			info, err = kb.GetByName(importKeyName)
+
+			assert.NotNil(t, info)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/gnovm/pkg/client/list.go
+++ b/gnovm/pkg/client/list.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"flag"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+func newListCmd(rootCfg *baseCfg) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "list",
+			ShortUsage: "list",
+			ShortHelp:  "Lists all keys in the keybase",
+		},
+		nil,
+		func(_ context.Context, args []string) error {
+			return execList(rootCfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func execList(cfg *baseCfg, args []string, io *commands.IO) error {
+	if len(args) != 0 {
+		return flag.ErrHelp
+	}
+
+	kb, err := keys.NewKeyBaseFromDir(cfg.Home)
+	if err != nil {
+		return err
+	}
+
+	infos, err := kb.List()
+	if err == nil {
+		printInfos(infos, io)
+	}
+
+	return err
+}
+
+func printInfos(infos []keys.Info, io *commands.IO) {
+	for i, info := range infos {
+		keyname := info.GetName()
+		keytype := info.GetType()
+		keypub := info.GetPubKey()
+		keyaddr := info.GetAddress()
+		keypath, _ := info.GetPath()
+		io.Printfln("%d. %s (%s) - addr: %v pub: %v, path: %v",
+			i, keyname, keytype, keyaddr, keypub, keypath)
+	}
+}

--- a/gnovm/pkg/client/list_test.go
+++ b/gnovm/pkg/client/list_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_execList(t *testing.T) {
+	// Prepare some keybases
+	kbHome1, cleanUp1 := testutils.NewTestCaseDir(t)
+	kbHome2, cleanUp2 := testutils.NewTestCaseDir(t)
+	defer cleanUp1()
+	defer cleanUp2()
+	// leave home1 and home2 empty
+
+	// initialize test keybase.
+	kb, err := keys.NewKeyBaseFromDir(kbHome2)
+	assert.NoError(t, err)
+	_, err = kb.CreateAccount("something", testMnemonic, "", "", 0, 0)
+	assert.NoError(t, err)
+
+	testData := []struct {
+		name    string
+		kbDir   string
+		args    []string
+		wantErr bool
+	}{
+		{"invalid keybase", "/dev/null", []string{}, true},
+		{"keybase: empty", kbHome1, []string{}, false},
+		{"keybase: w/key", kbHome2, []string{}, false},
+	}
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set current home
+			cfg := &baseCfg{
+				BaseOptions: BaseOptions{
+					Home: tt.kbDir,
+				},
+			}
+
+			args := tt.args
+			if err := execList(cfg, args, commands.NewTestIO()); (err != nil) != tt.wantErr {
+				t.Errorf("listApp() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/gnovm/pkg/client/maketx.go
+++ b/gnovm/pkg/client/maketx.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"flag"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+type makeTxCfg struct {
+	rootCfg *baseCfg
+
+	gasWanted int64
+	gasFee    string
+	memo      string
+
+	broadcast bool
+	chainID   string
+}
+
+func newMakeTxCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &makeTxCfg{
+		rootCfg: rootCfg,
+	}
+
+	cmd := commands.NewCommand(
+		commands.Metadata{
+			Name:       "maketx",
+			ShortUsage: "<subcommand> [flags] [<arg>...]",
+			ShortHelp:  "Composes a tx document to sign",
+		},
+		cfg,
+		commands.HelpExec,
+	)
+
+	cmd.AddSubCommands(
+		newAddPkgCmd(cfg),
+		newSendCmd(cfg),
+		newCallCmd(cfg),
+	)
+
+	return cmd
+}
+
+func (c *makeTxCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.Int64Var(
+		&c.gasWanted,
+		"gas-wanted",
+		0,
+		"gas requested for tx",
+	)
+
+	fs.StringVar(
+		&c.gasFee,
+		"gas-fee",
+		"",
+		"gas payment fee",
+	)
+
+	fs.StringVar(
+		&c.memo,
+		"memo",
+		"",
+		"any descriptive text",
+	)
+
+	fs.BoolVar(
+		&c.broadcast,
+		"broadcast",
+		false,
+		"sign and broadcast",
+	)
+
+	fs.StringVar(
+		&c.chainID,
+		"chainid",
+		"dev",
+		"chainid to sign for (only useful if --broadcast)",
+	)
+}

--- a/gnovm/pkg/client/query.go
+++ b/gnovm/pkg/client/query.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+)
+
+type queryCfg struct {
+	rootCfg *baseCfg
+
+	data   string
+	height int64
+	prove  bool
+
+	// internal
+	path string
+}
+
+func newQueryCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &queryCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "query",
+			ShortUsage: "query [flags] <path>",
+			ShortHelp:  "Makes an ABCI query",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execQuery(cfg, args)
+		},
+	)
+}
+
+func (c *queryCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.data,
+		"data",
+		"",
+		"query data bytes",
+	)
+
+	fs.Int64Var(
+		&c.height,
+		"height",
+		0,
+		"query height (not yet supported)",
+	)
+
+	fs.BoolVar(
+		&c.prove,
+		"prove",
+		false,
+		"prove query result (not yet supported)",
+	)
+}
+
+func execQuery(cfg *queryCfg, args []string) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	cfg.path = args[0]
+
+	qres, err := queryHandler(cfg)
+	if err != nil {
+		return err
+	}
+
+	if qres.Response.Error != nil {
+		fmt.Printf("Log: %s\n",
+			qres.Response.Log)
+		return qres.Response.Error
+	}
+	resdata := qres.Response.Data
+	// XXX in general, how do we know what to show?
+	// proof := qres.Response.Proof
+	height := qres.Response.Height
+	fmt.Printf("height: %d\ndata: %s\n",
+		height,
+		string(resdata))
+	return nil
+}
+
+func queryHandler(cfg *queryCfg) (*ctypes.ResultABCIQuery, error) {
+	remote := cfg.rootCfg.Remote
+	if remote == "" || remote == "y" {
+		return nil, errors.New("missing remote url")
+	}
+
+	data := []byte(cfg.data)
+	opts2 := client.ABCIQueryOptions{
+		// Height: height, XXX
+		// Prove: false, XXX
+	}
+	cli := client.NewHTTP(remote, "/websocket")
+	qres, err := cli.ABCIQueryWithOptions(
+		cfg.path, data, opts2)
+	if err != nil {
+		return nil, errors.Wrap(err, "querying")
+	}
+
+	return qres, nil
+}

--- a/gnovm/pkg/client/root.go
+++ b/gnovm/pkg/client/root.go
@@ -1,0 +1,76 @@
+// Dedicated to my love, Lexi.
+package client
+
+import (
+	"flag"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+const (
+	mnemonicEntropySize = 256
+)
+
+type baseCfg struct {
+	BaseOptions
+}
+
+func NewRootCmd() *commands.Command {
+	cfg := &baseCfg{}
+
+	cmd := commands.NewCommand(
+		commands.Metadata{
+			ShortUsage: "<subcommand> [flags] [<arg>...]",
+			LongHelp:   "Manages private keys for the node",
+		},
+		cfg,
+		commands.HelpExec,
+	)
+
+	cmd.AddSubCommands(
+		newAddCmd(cfg),
+		newDeleteCmd(cfg),
+		newGenerateCmd(cfg),
+		newExportCmd(cfg),
+		newImportCmd(cfg),
+		newListCmd(cfg),
+		newSignCmd(cfg),
+		newVerifyCmd(cfg),
+		newQueryCmd(cfg),
+		newBroadcastCmd(cfg),
+		newMakeTxCmd(cfg),
+	)
+
+	return cmd
+}
+
+func (c *baseCfg) RegisterFlags(fs *flag.FlagSet) {
+	// Base options
+	fs.StringVar(
+		&c.Home,
+		"home",
+		DefaultBaseOptions.Home,
+		"home directory",
+	)
+
+	fs.StringVar(
+		&c.Remote,
+		"remote",
+		DefaultBaseOptions.Remote,
+		"remote node URL",
+	)
+
+	fs.BoolVar(
+		&c.Quiet,
+		"quiet",
+		DefaultBaseOptions.Quiet,
+		"suppress output during execution",
+	)
+
+	fs.BoolVar(
+		&c.InsecurePasswordStdin,
+		"insecure-password-stdin",
+		DefaultBaseOptions.Quiet,
+		"WARNING! take password from stdin",
+	)
+}

--- a/gnovm/pkg/client/send.go
+++ b/gnovm/pkg/client/send.go
@@ -1,0 +1,130 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type sendCfg struct {
+	rootCfg *makeTxCfg
+
+	send string
+	to   string
+}
+
+func newSendCmd(rootCfg *makeTxCfg) *commands.Command {
+	cfg := &sendCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "send",
+			ShortUsage: "send [flags] <key-name or address>",
+			ShortHelp:  "Sends native currency",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execSend(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *sendCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.send,
+		"send",
+		"",
+		"send amount",
+	)
+
+	fs.StringVar(
+		&c.to,
+		"to",
+		"",
+		"destination address",
+	)
+}
+
+func execSend(cfg *sendCfg, args []string, io *commands.IO) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	if cfg.rootCfg.gasWanted == 0 {
+		return errors.New("gas-wanted not specified")
+	}
+	if cfg.rootCfg.gasFee == "" {
+		return errors.New("gas-fee not specified")
+	}
+	if cfg.send == "" {
+		return errors.New("send (amount) must be specified")
+	}
+	if cfg.to == "" {
+		return errors.New("to (destination address) must be specified")
+	}
+
+	// read account pubkey.
+	nameOrBech32 := args[0]
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.rootCfg.Home)
+	if err != nil {
+		return err
+	}
+	info, err := kb.GetByNameOrAddress(nameOrBech32)
+	if err != nil {
+		return err
+	}
+	fromAddr := info.GetAddress()
+	// info.GetPubKey()
+
+	// Parse to address.
+	toAddr, err := crypto.AddressFromBech32(cfg.to)
+	if err != nil {
+		return err
+	}
+
+	// Parse send amount.
+	send, err := std.ParseCoins(cfg.send)
+	if err != nil {
+		return errors.Wrap(err, "parsing send coins")
+	}
+
+	// parse gas wanted & fee.
+	gaswanted := cfg.rootCfg.gasWanted
+	gasfee, err := std.ParseCoin(cfg.rootCfg.gasFee)
+	if err != nil {
+		return errors.Wrap(err, "parsing gas fee coin")
+	}
+
+	// construct msg & tx and marshal.
+	msg := bank.MsgSend{
+		FromAddress: fromAddr,
+		ToAddress:   toAddr,
+		Amount:      send,
+	}
+	tx := std.Tx{
+		Msgs:       []std.Msg{msg},
+		Fee:        std.NewFee(gaswanted, gasfee),
+		Signatures: nil,
+		Memo:       cfg.rootCfg.memo,
+	}
+
+	if cfg.rootCfg.broadcast {
+		err := signAndBroadcast(cfg.rootCfg, args, tx, io)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Println(string(amino.MustMarshalJSON(tx)))
+	}
+	return nil
+}

--- a/gnovm/pkg/client/sign.go
+++ b/gnovm/pkg/client/sign.go
@@ -1,0 +1,209 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type signCfg struct {
+	rootCfg *baseCfg
+
+	txPath        string
+	chainID       string
+	accountNumber uint64
+	sequence      uint64
+	showSignBytes bool
+
+	// internal flags, when called programmatically
+	nameOrBech32 string
+	txJSON       []byte
+	pass         string
+}
+
+func newSignCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &signCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "sign",
+			ShortUsage: "sign [flags] <key-name or address>",
+			ShortHelp:  "Signs the document",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execSign(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *signCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.txPath,
+		"txpath",
+		"-",
+		"path to file of tx to sign",
+	)
+
+	fs.StringVar(
+		&c.chainID,
+		"chainid",
+		"dev",
+		"chainid to sign for",
+	)
+
+	fs.Uint64Var(
+		&c.accountNumber,
+		"number",
+		0,
+		"account number to sign with (required)",
+	)
+
+	fs.Uint64Var(
+		&c.sequence,
+		"sequence",
+		0,
+		"sequence to sign with (required)",
+	)
+
+	fs.BoolVar(
+		&c.showSignBytes,
+		"show-signbytes",
+		false,
+		"show sign bytes and quit",
+	)
+}
+
+func execSign(cfg *signCfg, args []string, io *commands.IO) error {
+	var err error
+
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	cfg.nameOrBech32 = args[0]
+
+	// read tx to sign
+	txpath := cfg.txPath
+	if txpath == "-" { // from stdin.
+		txjsonstr, err := io.GetString(
+			"Enter tx to sign, terminated by a newline.",
+		)
+		if err != nil {
+			return err
+		}
+		cfg.txJSON = []byte(txjsonstr)
+	} else { // from file
+		cfg.txJSON, err = os.ReadFile(txpath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cfg.rootCfg.Quiet {
+		cfg.pass, err = io.GetPassword(
+			"",
+			cfg.rootCfg.InsecurePasswordStdin,
+		)
+	} else {
+		cfg.pass, err = io.GetPassword(
+			"Enter password.",
+			cfg.rootCfg.InsecurePasswordStdin,
+		)
+	}
+	if err != nil {
+		return err
+	}
+
+	signedTx, err := SignHandler(cfg)
+	if err != nil {
+		return err
+	}
+
+	signedJSON, err := amino.MarshalJSON(signedTx)
+	if err != nil {
+		return err
+	}
+	io.Println(string(signedJSON))
+
+	return nil
+}
+
+func SignHandler(cfg *signCfg) (*std.Tx, error) {
+	var err error
+	var tx std.Tx
+
+	if cfg.txJSON == nil {
+		return nil, errors.New("invalid tx content")
+	}
+
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	if err != nil {
+		return nil, err
+	}
+
+	err = amino.UnmarshalJSON(cfg.txJSON, &tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// fill tx signatures.
+	signers := tx.GetSigners()
+	if tx.Signatures == nil {
+		for range signers {
+			tx.Signatures = append(tx.Signatures, std.Signature{
+				PubKey:    nil, // zero signature
+				Signature: nil, // zero signature
+			})
+		}
+	}
+
+	// validate document to sign.
+	err = tx.ValidateBasic()
+	if err != nil {
+		return nil, err
+	}
+
+	// derive sign doc bytes.
+	chainID := cfg.chainID
+	accountNumber := cfg.accountNumber
+	sequence := cfg.sequence
+	signbz := tx.GetSignBytes(chainID, accountNumber, sequence)
+	if cfg.showSignBytes {
+		fmt.Printf("sign bytes: %X\n", signbz)
+		return nil, nil
+	}
+
+	sig, pub, err := kb.Sign(cfg.nameOrBech32, cfg.pass, signbz)
+	if err != nil {
+		return nil, err
+	}
+	addr := pub.Address()
+	found := false
+	for i := range tx.Signatures {
+		// override signature for matching slot.
+		if signers[i] == addr {
+			found = true
+			tx.Signatures[i] = std.Signature{
+				PubKey:    pub,
+				Signature: sig,
+			}
+		}
+	}
+	if !found {
+		return nil, errors.New(
+			fmt.Sprintf("addr %v (%s) not in signer set", addr, cfg.nameOrBech32),
+		)
+	}
+
+	return &tx, nil
+}

--- a/gnovm/pkg/client/sign_test.go
+++ b/gnovm/pkg/client/sign_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	sdkutils "github.com/gnolang/gno/tm2/pkg/sdk/testutils"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_execSign(t *testing.T) {
+	t.Parallel()
+
+	// make new test dir
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	assert.NotNil(t, kbHome)
+	defer kbCleanUp()
+
+	// initialize test options
+	cfg := &signCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+		txPath:        "-", // stdin
+		chainID:       "dev",
+		accountNumber: 0,
+		sequence:      0,
+	}
+
+	fakeKeyName1 := "signApp_Key1"
+	fakeKeyName2 := "signApp_Key2"
+	encPassword := "12345678"
+
+	io := commands.NewTestIO()
+
+	// add test account to keybase.
+	kb, err := keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	assert.NoError(t, err)
+	acc, err := kb.CreateAccount(fakeKeyName1, testMnemonic, "", encPassword, 0, 0)
+	addr := acc.GetAddress()
+	assert.NoError(t, err)
+
+	// create a tx to sign.
+	msg := sdkutils.NewTestMsg(addr)
+	fee := std.NewFee(1, std.Coin{"ugnot", 1000000})
+	tx := std.NewTx([]std.Msg{msg}, fee, nil, "")
+	txjson := string(amino.MustMarshalJSON(tx))
+
+	args := []string{fakeKeyName1}
+	io.SetIn(strings.NewReader(txjson))
+	err = execSign(cfg, args, io)
+	assert.Error(t, err)
+
+	args = []string{fakeKeyName1}
+	io.SetIn(strings.NewReader(txjson + "\n"))
+	err = execSign(cfg, args, io)
+	assert.Error(t, err)
+
+	args = []string{fakeKeyName2}
+	io.SetIn(strings.NewReader(
+		fmt.Sprintf("%s\n%s\n",
+			txjson,
+			encPassword,
+		),
+	))
+	err = execSign(cfg, args, io)
+	assert.Error(t, err)
+
+	args = []string{fakeKeyName1}
+	io.SetIn(strings.NewReader(
+		fmt.Sprintf("%s\n%s\n",
+			txjson,
+			encPassword,
+		),
+	))
+	err = execSign(cfg, args, io)
+	assert.NoError(t, err)
+}

--- a/gnovm/pkg/client/verify.go
+++ b/gnovm/pkg/client/verify.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+type verifyCfg struct {
+	rootCfg *baseCfg
+
+	docPath string
+}
+
+func newVerifyCmd(rootCfg *baseCfg) *commands.Command {
+	cfg := &verifyCfg{
+		rootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "verify",
+			ShortUsage: "verify [flags] <key-name> <signature>",
+			ShortHelp:  "Verifies the document signature",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execVerify(cfg, args, commands.NewDefaultIO())
+		},
+	)
+}
+
+func (c *verifyCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.docPath,
+		"docpath",
+		"",
+		"path of document file to verify",
+	)
+}
+
+func execVerify(cfg *verifyCfg, args []string, io *commands.IO) error {
+	var (
+		kb  keys.Keybase
+		err error
+	)
+
+	if len(args) != 2 {
+		return flag.ErrHelp
+	}
+
+	name := args[0]
+	sig, err := parseSignature(args[1])
+	if err != nil {
+		return err
+	}
+	docpath := cfg.docPath
+	kb, err = keys.NewKeyBaseFromDir(cfg.rootCfg.Home)
+	if err != nil {
+		return err
+	}
+	msg := []byte{}
+
+	// read document to sign
+	if docpath == "" { // from stdin.
+		msgstr, err := io.GetString(
+			"Enter document to sign.",
+		)
+		if err != nil {
+			return err
+		}
+		msg = []byte(msgstr)
+	} else { // from file
+		msg, err = os.ReadFile(docpath)
+		if err != nil {
+			return err
+		}
+	}
+
+	// validate document to sign.
+	// XXX
+
+	// verify signature.
+	err = kb.Verify(name, msg, sig)
+	if err == nil {
+		io.Println("Valid signature!")
+	}
+	return err
+}
+
+func parseSignature(sigstr string) ([]byte, error) {
+	sig, err := hex.DecodeString(sigstr)
+	if err != nil {
+		return nil, err
+	}
+	return sig, nil
+}

--- a/gnovm/pkg/client/verify_test.go
+++ b/gnovm/pkg/client/verify_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_execVerify(t *testing.T) {
+	t.Parallel()
+
+	// make new test dir
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	assert.NotNil(t, kbHome)
+	defer kbCleanUp()
+
+	// initialize test options
+	cfg := &verifyCfg{
+		rootCfg: &baseCfg{
+			BaseOptions: BaseOptions{
+				Home:                  kbHome,
+				InsecurePasswordStdin: true,
+			},
+		},
+		docPath: "",
+	}
+
+	io := commands.NewTestIO()
+
+	fakeKeyName1 := "verifyApp_Key1"
+	// encPassword := "12345678"
+	encPassword := ""
+	testMsg := "some message"
+
+	// add test account to keybase.
+	kb, err := keys.NewKeyBaseFromDir(kbHome)
+	assert.NoError(t, err)
+	_, err = kb.CreateAccount(fakeKeyName1, testMnemonic, "", encPassword, 0, 0)
+	assert.NoError(t, err)
+
+	// sign test message.
+	priv, err := kb.ExportPrivateKeyObject(fakeKeyName1, encPassword)
+	assert.NoError(t, err)
+	testSig, err := priv.Sign([]byte(testMsg))
+	assert.NoError(t, err)
+	testSigHex := hex.EncodeToString(testSig)
+
+	// good signature passes test.
+	args := []string{fakeKeyName1, testSigHex}
+	io.SetIn(
+		strings.NewReader(
+			fmt.Sprintf("%s\n", testMsg),
+		),
+	)
+	err = execVerify(cfg, args, io)
+	assert.NoError(t, err)
+
+	// mutated bad signature fails test.
+	testBadSig := testutils.MutateByteSlice(testSig)
+	testBadSigHex := hex.EncodeToString(testBadSig)
+	args = []string{fakeKeyName1, testBadSigHex}
+	io.SetIn(
+		strings.NewReader(
+			fmt.Sprintf("%s\n", testMsg),
+		),
+	)
+	err = execVerify(cfg, args, io)
+	assert.Error(t, err)
+}

--- a/gnovm/pkg/vm/builtins.go
+++ b/gnovm/pkg/vm/builtins.go
@@ -1,0 +1,127 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/gnovm/stdlibs"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	osm "github.com/gnolang/gno/tm2/pkg/os"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+func (vm *VMKeeper) initBuiltinPackagesAndTypes(store gno.Store) {
+	// NOTE: native functions/methods added here must be quick operations,
+	// or account for gas before operation.
+	// TODO: define criteria for inclusion, and solve gas calculations.
+	getPackage := func(pkgPath string) (pn *gno.PackageNode, pv *gno.PackageValue) {
+		// otherwise, built-in package value.
+		// first, load from filepath.
+		stdlibPath := filepath.Join(vm.stdlibsDir, pkgPath)
+		if !osm.DirExists(stdlibPath) {
+			// does not exist.
+			return nil, nil
+		}
+		memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
+		m2 := gno.NewMachineWithOptions(gno.MachineOptions{
+			PkgPath: "gno.land/r/stdlibs/" + pkgPath,
+			// PkgPath: pkgPath,
+			Output: os.Stdout,
+			Store:  store,
+		})
+		defer m2.Release()
+		return m2.RunMemPackage(memPkg, true)
+	}
+	store.SetPackageGetter(getPackage)
+	store.SetPackageInjector(vm.packageInjector)
+	stdlibs.InjectNativeMappings(store)
+}
+
+func (vm *VMKeeper) packageInjector(store gno.Store, pn *gno.PackageNode) {
+	// Also inject stdlibs native functions.
+	stdlibs.InjectPackage(store, pn)
+	// vm (this package) specific injections:
+	switch pn.PkgPath {
+	case "std":
+		/* XXX deleteme
+		// Also see stdlibs/InjectPackage.
+		pn.DefineNative("AssertOriginCall",
+			gno.Flds( // params
+			),
+			gno.Flds( // results
+			),
+			func(m *gno.Machine) {
+				isOrigin := len(m.Frames) == 2
+				if !isOrigin {
+					panic("invalid non-origin call")
+				}
+			},
+		)
+		pn.DefineNative("IsOriginCall",
+			gno.Flds( // params
+			),
+			gno.Flds( // results
+				"isOrigin", "bool",
+			),
+			func(m *gno.Machine) {
+				isOrigin := len(m.Frames) == 2
+				res0 := gno.TypedValue{T: gno.BoolType}
+				res0.SetBool(isOrigin)
+				m.PushValue(res0)
+			},
+		)
+		*/
+	}
+}
+
+// ----------------------------------------
+// SDKBanker
+
+type SDKBanker struct {
+	vmk *VMKeeper
+	ctx sdk.Context
+}
+
+func NewSDKBanker(vmk *VMKeeper, ctx sdk.Context) *SDKBanker {
+	return &SDKBanker{
+		vmk: vmk,
+		ctx: ctx,
+	}
+}
+
+func (bnk *SDKBanker) GetCoins(b32addr crypto.Bech32Address) (dst std.Coins) {
+	addr := crypto.MustAddressFromString(string(b32addr))
+	coins := bnk.vmk.bank.GetCoins(bnk.ctx, addr)
+	return coins
+}
+
+func (bnk *SDKBanker) SendCoins(b32from, b32to crypto.Bech32Address, amt std.Coins) {
+	from := crypto.MustAddressFromString(string(b32from))
+	to := crypto.MustAddressFromString(string(b32to))
+	err := bnk.vmk.bank.SendCoins(bnk.ctx, from, to, amt)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (bnk *SDKBanker) TotalCoin(denom string) int64 {
+	panic("not yet implemented")
+}
+
+func (bnk *SDKBanker) IssueCoin(b32addr crypto.Bech32Address, denom string, amount int64) {
+	addr := crypto.MustAddressFromString(string(b32addr))
+	_, err := bnk.vmk.bank.AddCoins(bnk.ctx, addr, std.Coins{std.Coin{denom, amount}})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (bnk *SDKBanker) RemoveCoin(b32addr crypto.Bech32Address, denom string, amount int64) {
+	addr := crypto.MustAddressFromString(string(b32addr))
+	_, err := bnk.vmk.bank.SubtractCoins(bnk.ctx, addr, std.Coins{std.Coin{denom, amount}})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/gnovm/pkg/vm/common_test.go
+++ b/gnovm/pkg/vm/common_test.go
@@ -1,0 +1,48 @@
+package vm
+
+// DONTCOVER
+
+import (
+	"path/filepath"
+
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/log"
+
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	authm "github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	bankm "github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	"github.com/gnolang/gno/tm2/pkg/store/iavl"
+)
+
+type testEnv struct {
+	ctx  sdk.Context
+	vmk  *VMKeeper
+	bank bankm.BankKeeper
+	acck authm.AccountKeeper
+}
+
+func setupTestEnv() testEnv {
+	db := dbm.NewMemDB()
+
+	baseCapKey := store.NewStoreKey("baseCapKey")
+	iavlCapKey := store.NewStoreKey("iavlCapKey")
+
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(baseCapKey, dbadapter.StoreConstructor, db)
+	ms.MountStoreWithDB(iavlCapKey, iavl.StoreConstructor, db)
+	ms.LoadLatestVersion()
+
+	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms, &bft.Header{ChainID: "test-chain-id"}, log.NewNopLogger())
+	acck := authm.NewAccountKeeper(iavlCapKey, std.ProtoBaseAccount)
+	bank := bankm.NewBankKeeper(acck)
+	stdlibsDir := filepath.Join("..", "..", "..", "..", "gnovm", "stdlibs")
+	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir)
+
+	vmk.Initialize(ms.MultiCacheWrap())
+
+	return testEnv{ctx: ctx, vmk: vmk, bank: bank, acck: acck}
+}

--- a/gnovm/pkg/vm/consts.go
+++ b/gnovm/pkg/vm/consts.go
@@ -1,0 +1,6 @@
+package vm
+
+const (
+	ModuleName = "vm"
+	RouterKey  = ModuleName
+)

--- a/gnovm/pkg/vm/convert.go
+++ b/gnovm/pkg/vm/convert.go
@@ -1,0 +1,197 @@
+package vm
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+)
+
+// These convert string representations of public-facing arguments to GNO types.
+// The limited set of input types available should map 1:1 to types supported
+// in FunctionSignature{}.
+// String representation of arg must be deterministic.
+// NOTE: very important that there is no malleability.
+func convertArgToGno(arg string, argT gno.Type) (tv gno.TypedValue) {
+	tv.T = argT
+	switch bt := gno.BaseOf(argT).(type) {
+	case gno.PrimitiveType:
+		switch bt {
+		case gno.BoolType:
+			if arg == "true" {
+				tv.SetBool(true)
+				return
+			} else if arg == "false" {
+				tv.SetBool(false)
+				return
+			} else {
+				panic(fmt.Sprintf(
+					"unexpected bool value %q",
+					arg))
+			}
+		case gno.StringType:
+			tv.SetString(gno.StringValue(arg))
+			return
+		case gno.IntType:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			i64, err := strconv.ParseInt(arg, 10, 64)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing int %q: %v",
+					arg, err))
+			}
+			tv.SetInt(int(i64))
+			return
+		case gno.Int8Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			i8, err := strconv.ParseInt(arg, 10, 8)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing int8 %q: %v",
+					arg, err))
+			}
+			tv.SetInt8(int8(i8))
+			return
+		case gno.Int16Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			i16, err := strconv.ParseInt(arg, 10, 16)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing int16 %q: %v",
+					arg, err))
+			}
+			tv.SetInt16(int16(i16))
+			return
+		case gno.Int32Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			i32, err := strconv.ParseInt(arg, 10, 32)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing int32 %q: %v",
+					arg, err))
+			}
+			tv.SetInt32(int32(i32))
+			return
+		case gno.Int64Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			i64, err := strconv.ParseInt(arg, 10, 64)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing int64 %q: %v",
+					arg, err))
+			}
+			tv.SetInt64(i64)
+			return
+		case gno.UintType:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			u64, err := strconv.ParseUint(arg, 10, 64)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing uint %q: %v",
+					arg, err))
+			}
+			tv.SetUint(uint(u64))
+			return
+		case gno.Uint8Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			u8, err := strconv.ParseUint(arg, 10, 8)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing uint8 %q: %v",
+					arg, err))
+			}
+			tv.SetUint8(uint8(u8))
+			return
+		case gno.Uint16Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			u16, err := strconv.ParseUint(arg, 10, 16)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing uint16 %q: %v",
+					arg, err))
+			}
+			tv.SetUint16(uint16(u16))
+			return
+		case gno.Uint32Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			u32, err := strconv.ParseUint(arg, 10, 32)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing uint32 %q: %v",
+					arg, err))
+			}
+			tv.SetUint32(uint32(u32))
+			return
+		case gno.Uint64Type:
+			if arg[0] == '+' {
+				panic("numbers cannot start with +")
+			}
+			u64, err := strconv.ParseUint(arg, 10, 64)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing uint64 %q: %v",
+					arg, err))
+			}
+			tv.SetUint64(u64)
+			return
+		default:
+			panic(fmt.Sprintf("unexpected primitive type %s", bt.String()))
+		}
+	case *gno.ArrayType:
+		if bt.Elt == gno.Uint8Type {
+			bz, err := base64.StdEncoding.DecodeString(arg)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing byte array %q: %v",
+					arg, err))
+			}
+			tv.V = &gno.ArrayValue{
+				Data: bz,
+			}
+			return
+		} else {
+			panic("unexpected array type in contract arg")
+		}
+	case *gno.SliceType:
+		if bt.Elt == gno.Uint8Type {
+			bz, err := base64.StdEncoding.DecodeString(arg)
+			if err != nil {
+				panic(fmt.Sprintf(
+					"error parsing byte array %q: %v",
+					arg, err))
+			}
+			tv.V = &gno.SliceValue{
+				Base: &gno.ArrayValue{
+					Data: bz,
+				},
+				Offset: 0,
+				Length: len(bz),
+				Maxcap: len(bz),
+			}
+			return
+		} else {
+			panic("unexpected slice type in contract arg")
+		}
+	default:
+		panic(fmt.Sprintf("unexpected type in contract arg: %v", argT))
+	}
+}

--- a/gnovm/pkg/vm/errors.go
+++ b/gnovm/pkg/vm/errors.go
@@ -1,0 +1,33 @@
+package vm
+
+import "github.com/gnolang/gno/tm2/pkg/errors"
+
+// for convenience:
+type abciError struct{}
+
+func (abciError) AssertABCIError() {}
+
+// declare all script errors.
+// NOTE: these are meant to be used in conjunction with pkgs/errors.
+type InvalidPkgPathError struct{ abciError }
+
+type (
+	InvalidStmtError struct{ abciError }
+	InvalidExprError struct{ abciError }
+)
+
+func (e InvalidPkgPathError) Error() string { return "invalid package path" }
+func (e InvalidStmtError) Error() string    { return "invalid statement" }
+func (e InvalidExprError) Error() string    { return "invalid expression" }
+
+func ErrInvalidPkgPath(msg string) error {
+	return errors.Wrap(InvalidPkgPathError{}, msg)
+}
+
+func ErrInvalidStmt(msg string) error {
+	return errors.Wrap(InvalidStmtError{}, msg)
+}
+
+func ErrInvalidExpr(msg string) error {
+	return errors.Wrap(InvalidExprError{}, msg)
+}

--- a/gnovm/pkg/vm/handler.go
+++ b/gnovm/pkg/vm/handler.go
@@ -1,0 +1,214 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type vmHandler struct {
+	vm *VMKeeper
+}
+
+// NewHandler returns a handler for "vm" type messages.
+func NewHandler(vm *VMKeeper) vmHandler {
+	return vmHandler{
+		vm: vm,
+	}
+}
+
+func (vh vmHandler) Process(ctx sdk.Context, msg std.Msg) sdk.Result {
+	switch msg := msg.(type) {
+	case MsgAddPackage:
+		return vh.handleMsgAddPackage(ctx, msg)
+	case MsgCall:
+		return vh.handleMsgCall(ctx, msg)
+	default:
+		errMsg := fmt.Sprintf("unrecognized vm message type: %T", msg)
+		return abciResult(std.ErrUnknownRequest(errMsg))
+	}
+}
+
+// Handle MsgAddPackage.
+func (vh vmHandler) handleMsgAddPackage(ctx sdk.Context, msg MsgAddPackage) sdk.Result {
+	amount, err := std.ParseCoins("1000000ugnot") // XXX calculate
+	if err != nil {
+		return abciResult(err)
+	}
+	err = vh.vm.bank.SendCoins(ctx, msg.Creator, auth.FeeCollectorAddress(), amount)
+	if err != nil {
+		return abciResult(err)
+	}
+	err = vh.vm.AddPackage(ctx, msg)
+	if err != nil {
+		return abciResult(err)
+	}
+	return sdk.Result{}
+}
+
+// Handle MsgCall.
+func (vh vmHandler) handleMsgCall(ctx sdk.Context, msg MsgCall) (res sdk.Result) {
+	amount, err := std.ParseCoins("1000000ugnot") // XXX calculate
+	if err != nil {
+		return abciResult(err)
+	}
+	err = vh.vm.bank.SendCoins(ctx, msg.Caller, auth.FeeCollectorAddress(), amount)
+	if err != nil {
+		return abciResult(err)
+	}
+	resstr := ""
+	resstr, err = vh.vm.Call(ctx, msg)
+	if err != nil {
+		return abciResult(err)
+	}
+	res.Data = []byte(resstr)
+	return
+	/* TODO handle events.
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyXXX, types.AttributeValueXXX),
+		),
+	)
+	*/
+}
+
+//----------------------------------------
+// Query
+
+// query paths
+const (
+	QueryPackage = "package"
+	QueryStore   = "store"
+	QueryRender  = "qrender"
+	QueryFuncs   = "qfuncs"
+	QueryEval    = "qeval"
+	QueryFile    = "qfile"
+)
+
+func (vh vmHandler) Query(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	switch secondPart(req.Path) {
+	case QueryPackage:
+		return vh.queryPackage(ctx, req)
+	case QueryStore:
+		return vh.queryStore(ctx, req)
+	case QueryRender:
+		return vh.queryRender(ctx, req)
+	case QueryFuncs:
+		return vh.queryFuncs(ctx, req)
+	case QueryEval:
+		return vh.queryEval(ctx, req)
+	case QueryFile:
+		return vh.queryFile(ctx, req)
+	default:
+		res = sdk.ABCIResponseQueryFromError(
+			std.ErrUnknownRequest(fmt.Sprintf(
+				"unknown vm query endpoint %s in %s",
+				secondPart(req.Path), req.Path)))
+		return
+	}
+}
+
+// queryPackage fetch a package's files.
+func (vh vmHandler) queryPackage(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	res.Data = []byte(fmt.Sprintf("TODO: parse parts get or make fileset..."))
+	return
+}
+
+// queryPackage fetch items from the store.
+func (vh vmHandler) queryStore(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	res.Data = []byte(fmt.Sprintf("TODO: fetch from store"))
+	return
+}
+
+// queryRender calls .Render(<path>) in readonly mode.
+func (vh vmHandler) queryRender(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	reqData := string(req.Data)
+	reqParts := strings.Split(reqData, "\n")
+	if len(reqParts) != 2 {
+		panic("expected two lines in query input data")
+	}
+	pkgPath := reqParts[0]
+	path := reqParts[1]
+	expr := fmt.Sprintf("Render(%q)", path)
+	result, err := vh.vm.QueryEvalString(ctx, pkgPath, expr)
+	if err != nil {
+		res = sdk.ABCIResponseQueryFromError(err)
+		return
+	}
+	res.Data = []byte(result)
+	return
+}
+
+// queryFuncs returns public facing function signatures as JSON.
+func (vh vmHandler) queryFuncs(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	reqData := string(req.Data)
+	reqParts := strings.Split(reqData, "\n")
+	if len(reqParts) != 1 {
+		panic("expected one line in query input data")
+	}
+	pkgPath := reqParts[0]
+	fsigs, err := vh.vm.QueryFuncs(ctx, pkgPath)
+	if err != nil {
+		res = sdk.ABCIResponseQueryFromError(err)
+		return
+	}
+	res.Data = []byte(fsigs.JSON())
+	return
+}
+
+// queryEval evaluates any expression in readonly mode and returns the results.
+func (vh vmHandler) queryEval(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	reqData := string(req.Data)
+	reqParts := strings.Split(reqData, "\n")
+	if len(reqParts) != 2 {
+		panic("expected two lines in query input data")
+	}
+	pkgPath := reqParts[0]
+	expr := reqParts[1]
+	result, err := vh.vm.QueryEval(ctx, pkgPath, expr)
+	if err != nil {
+		res = sdk.ABCIResponseQueryFromError(err)
+		return
+	}
+	res.Data = []byte(result)
+	return
+}
+
+// queryFile returns the file bytes, or list of files if directory.
+// if file, res.Value is []byte("file").
+// if dir, res.Value is []byte("dir").
+func (vh vmHandler) queryFile(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
+	filepath := string(req.Data)
+	result, err := vh.vm.QueryFile(ctx, filepath)
+	if err != nil {
+		res = sdk.ABCIResponseQueryFromError(err)
+		return
+	}
+	res.Data = []byte(result)
+	return
+}
+
+//----------------------------------------
+// misc
+
+func abciResult(err error) sdk.Result {
+	return sdk.ABCIResultFromError(err)
+}
+
+// returns the second component of a path.
+func secondPart(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return ""
+	} else {
+		if parts[0] != "vm" {
+			panic("should not happen")
+		}
+		return parts[1]
+	}
+}

--- a/gnovm/pkg/vm/handler_test.go
+++ b/gnovm/pkg/vm/handler_test.go
@@ -1,0 +1,58 @@
+package vm
+
+/*
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	tu "github.com/gnolang/gno/tm2/pkg/sdk/testutils"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+func TestInvalidMsg(t *testing.T) {
+	h := NewHandler(BankKeeper{})
+	res := h.Process(sdk.NewContext(nil, &bft.Header{}, false, nil), tu.NewTestMsg())
+	require.False(t, res.IsOK())
+	require.True(t, strings.Contains(res.Log, "unrecognized bank message type"))
+}
+
+func TestBalances(t *testing.T) {
+	env := setupTestEnv()
+	h := NewHandler(env.bank)
+	req := abci.RequestQuery{
+		Path: fmt.Sprintf("bank/%s", QueryBalance),
+		Data: []byte{},
+	}
+
+	res := h.Query(env.ctx, req)
+	require.NotNil(t, res.Error)
+
+	_, _, addr := tu.KeyTestPubAddr()
+	req.Data = amino.MustMarshalJSON(NewQueryBalanceParams(addr))
+	res = h.Query(env.ctx, req)
+	require.Nil(t, res.Error) // the account does not exist, no error returned anyway
+	require.NotNil(t, res)
+
+	var coins std.Coins
+	require.NoError(t, amino.UnmarshalJSON(res.Data, &coins))
+	require.True(t, coins.IsZero())
+
+	acc := env.acck.NewAccountWithAddress(env.ctx, addr)
+	acc.SetCoins(std.NewCoins(std.NewCoin("foo", 10)))
+	env.acck.SetAccount(env.ctx, acc)
+	res = h.Query(env.ctx, req)
+	require.Nil(t, res.Error)
+	require.NotNil(t, res)
+	require.NoError(t, amino.UnmarshalJSON(res.Data, &coins))
+	require.True(t, coins.AmountOf("foo") == 10)
+}
+
+*/

--- a/gnovm/pkg/vm/invariants.go
+++ b/gnovm/pkg/vm/invariants.go
@@ -1,0 +1,36 @@
+package vm
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+)
+
+// RegisterInvariants registers the vm module invariants
+func RegisterInvariants(ir sdk.InvariantRegistry, vmk VMKeeper) {
+	// ir.RegisterRoute(ModuleName, "nonnegative-outstanding",
+	//	NonnegativeBalanceInvariant(acck))
+}
+
+/* TODO write new invariants for vm.
+// NonnegativeBalanceInvariant checks that all accounts in the application have non-negative balances
+func NonnegativeBalanceInvariant(acck auth.AccountKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var msg string
+		var count int
+
+		accts := acck.GetAllAccounts(ctx)
+		for _, acc := range accts {
+			coins := acc.GetCoins()
+			if coins.IsAnyNegative() {
+				count++
+				msg += fmt.Sprintf("\t%s has a negative denomination of %s\n",
+					acc.GetAddress().String(),
+					coins.String())
+			}
+		}
+		broken := count != 0
+
+		return sdk.FormatInvariant(ModuleName, "nonnegative-outstanding",
+			fmt.Sprintf("amount of negative accounts found %d\n%s", count, msg)), broken
+	}
+}
+*/

--- a/gnovm/pkg/vm/keeper.go
+++ b/gnovm/pkg/vm/keeper.go
@@ -1,0 +1,471 @@
+package vm
+
+// TODO: move most of the logic in ROOT/gno.land/...
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/gnovm/stdlibs"
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store"
+)
+
+const (
+	maxAllocTx    = 500 * 1000 * 1000
+	maxAllocQuery = 1500 * 1000 * 1000 // higher limit for queries
+)
+
+// vm.VMKeeperI defines a module interface that supports Gno
+// smart contracts programming (scripting).
+type VMKeeperI interface {
+	AddPackage(ctx sdk.Context, msg MsgAddPackage) error
+	Call(ctx sdk.Context, msg MsgCall) (res string, err error)
+}
+
+var _ VMKeeperI = &VMKeeper{}
+
+// VMKeeper holds all package code and store state.
+type VMKeeper struct {
+	baseKey    store.StoreKey
+	iavlKey    store.StoreKey
+	acck       auth.AccountKeeper
+	bank       bank.BankKeeper
+	stdlibsDir string
+
+	// cached, the DeliverTx persistent state.
+	gnoStore gno.Store
+}
+
+// NewVMKeeper returns a new VMKeeper.
+func NewVMKeeper(baseKey store.StoreKey, iavlKey store.StoreKey, acck auth.AccountKeeper, bank bank.BankKeeper, stdlibsDir string) *VMKeeper {
+	vmk := &VMKeeper{
+		baseKey:    baseKey,
+		iavlKey:    iavlKey,
+		acck:       acck,
+		bank:       bank,
+		stdlibsDir: stdlibsDir,
+	}
+	return vmk
+}
+
+func (vm *VMKeeper) Initialize(ms store.MultiStore) {
+	if vm.gnoStore != nil {
+		panic("should not happen")
+	}
+	alloc := gno.NewAllocator(maxAllocTx)
+	baseSDKStore := ms.GetStore(vm.baseKey)
+	iavlSDKStore := ms.GetStore(vm.iavlKey)
+	vm.gnoStore = gno.NewStore(alloc, baseSDKStore, iavlSDKStore)
+	vm.initBuiltinPackagesAndTypes(vm.gnoStore)
+	if vm.gnoStore.NumMemPackages() > 0 {
+		// for now, all mem packages must be re-run after reboot.
+		// TODO remove this, and generally solve for in-mem garbage collection
+		// and memory management across many objects/types/nodes/packages.
+		m2 := gno.NewMachineWithOptions(
+			gno.MachineOptions{
+				PkgPath: "",
+				Output:  os.Stdout, // XXX
+				Store:   vm.gnoStore,
+			})
+		defer m2.Release()
+		gno.DisableDebug()
+		m2.PreprocessAllFilesAndSaveBlockNodes()
+		gno.EnableDebug()
+	}
+}
+
+func (vm *VMKeeper) getGnoStore(ctx sdk.Context) gno.Store {
+	// construct main gnoStore if nil.
+	if vm.gnoStore == nil {
+		panic("VMKeeper must first be initialized")
+	}
+	switch ctx.Mode() {
+	case sdk.RunTxModeDeliver:
+		// swap sdk store of existing gnoStore.
+		// this is needed due to e.g. gas wrappers.
+		baseSDKStore := ctx.Store(vm.baseKey)
+		iavlSDKStore := ctx.Store(vm.iavlKey)
+		vm.gnoStore.SwapStores(baseSDKStore, iavlSDKStore)
+		// clear object cache for every transaction.
+		// NOTE: this is inefficient, but simple.
+		// in the future, replace with more advanced caching strategy.
+		vm.gnoStore.ClearObjectCache()
+		return vm.gnoStore
+	case sdk.RunTxModeCheck:
+		// For query??? XXX Why not RunTxModeQuery?
+		simStore := vm.gnoStore.Fork()
+		baseSDKStore := ctx.Store(vm.baseKey)
+		iavlSDKStore := ctx.Store(vm.iavlKey)
+		simStore.SwapStores(baseSDKStore, iavlSDKStore)
+		return simStore
+	case sdk.RunTxModeSimulate:
+		// always make a new store for simulate for isolation.
+		simStore := vm.gnoStore.Fork()
+		baseSDKStore := ctx.Store(vm.baseKey)
+		iavlSDKStore := ctx.Store(vm.iavlKey)
+		simStore.SwapStores(baseSDKStore, iavlSDKStore)
+		return simStore
+	default:
+		panic("should not happen")
+	}
+}
+
+// AddPackage adds a package with given fileset.
+func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
+	creator := msg.Creator
+	pkgPath := msg.Package.Path
+	memPkg := msg.Package
+	deposit := msg.Deposit
+	store := vm.getGnoStore(ctx)
+
+	// Validate arguments.
+	if creator.IsZero() {
+		return std.ErrInvalidAddress("missing creator address")
+	}
+	creatorAcc := vm.acck.GetAccount(ctx, creator)
+	if creatorAcc == nil {
+		return std.ErrUnknownAddress(fmt.Sprintf("account %s does not exist", creator))
+	}
+	if err := msg.Package.Validate(); err != nil {
+		return ErrInvalidPkgPath(err.Error())
+	}
+	if pv := store.GetPackage(pkgPath, false); pv != nil {
+		// TODO: return error instead of panicking?
+		panic("package already exists: " + pkgPath)
+	}
+	// Pay deposit from creator.
+	pkgAddr := gno.DerivePkgAddr(pkgPath)
+
+	// TODO: ACLs.
+	// - if r/system/names does not exists -> skip validation.
+	// - loads r/system/names data state.
+	// - lookup r/system/names.namespaces for `{r,p}/NAMES`.
+	// - check if caller is in Admins or Editors.
+	// - check if namespace is not in pause.
+
+	err := vm.bank.SendCoins(ctx, creator, pkgAddr, deposit)
+	if err != nil {
+		return err
+	}
+	// Parse and run the files, construct *PV.
+	msgCtx := stdlibs.ExecContext{
+		ChainID:       ctx.ChainID(),
+		Height:        ctx.BlockHeight(),
+		Timestamp:     ctx.BlockTime().Unix(),
+		Msg:           msg,
+		OrigCaller:    creator.Bech32(),
+		OrigSend:      deposit,
+		OrigSendSpent: new(std.Coins),
+		OrigPkgAddr:   pkgAddr.Bech32(),
+		Banker:        NewSDKBanker(vm, ctx),
+	}
+	// Parse and run the files, construct *PV.
+	m2 := gno.NewMachineWithOptions(
+		gno.MachineOptions{
+			PkgPath:   "",
+			Output:    os.Stdout, // XXX
+			Store:     store,
+			Alloc:     store.GetAllocator(),
+			Context:   msgCtx,
+			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+		})
+	defer m2.Release()
+	m2.RunMemPackage(memPkg, true)
+	fmt.Println("CPUCYCLES addpkg", m2.Cycles)
+	return nil
+}
+
+// Calls calls a public Gno function (for delivertx).
+func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
+	pkgPath := msg.PkgPath // to import
+	fnc := msg.Func
+	store := vm.getGnoStore(ctx)
+	// Get the package and function type.
+	pv := store.GetPackage(pkgPath, false)
+	pl := gno.PackageNodeLocation(pkgPath)
+	pn := store.GetBlockNode(pl).(*gno.PackageNode)
+	ft := pn.GetStaticTypeOf(store, gno.Name(fnc)).(*gno.FuncType)
+	// Make main Package with imports.
+	mpn := gno.NewPackageNode("main", "main", nil)
+	mpn.Define("pkg", gno.TypedValue{T: &gno.PackageType{}, V: pv})
+	mpv := mpn.NewPackage()
+	// Parse expression.
+	argslist := ""
+	for i := range msg.Args {
+		if i > 0 {
+			argslist += ","
+		}
+		argslist += fmt.Sprintf("arg%d", i)
+	}
+	expr := fmt.Sprintf(`pkg.%s(%s)`, fnc, argslist)
+	xn := gno.MustParseExpr(expr)
+	// Send send-coins to pkg from caller.
+	pkgAddr := gno.DerivePkgAddr(pkgPath)
+	caller := msg.Caller
+	send := msg.Send
+	err = vm.bank.SendCoins(ctx, caller, pkgAddr, send)
+	if err != nil {
+		return "", err
+	}
+	// Convert Args to gno values.
+	cx := xn.(*gno.CallExpr)
+	if cx.Varg {
+		panic("variadic calls not yet supported")
+	}
+	for i, arg := range msg.Args {
+		argType := ft.Params[i].Type
+		atv := convertArgToGno(arg, argType)
+		cx.Args[i] = &gno.ConstExpr{
+			TypedValue: atv,
+		}
+	}
+	// Make context.
+	// NOTE: if this is too expensive,
+	// could it be safely partially memoized?
+	msgCtx := stdlibs.ExecContext{
+		ChainID:       ctx.ChainID(),
+		Height:        ctx.BlockHeight(),
+		Timestamp:     ctx.BlockTime().Unix(),
+		Msg:           msg,
+		OrigCaller:    caller.Bech32(),
+		OrigSend:      send,
+		OrigSendSpent: new(std.Coins),
+		OrigPkgAddr:   pkgAddr.Bech32(),
+		Banker:        NewSDKBanker(vm, ctx),
+	}
+	// Construct machine and evaluate.
+	m := gno.NewMachineWithOptions(
+		gno.MachineOptions{
+			PkgPath:   "",
+			Output:    os.Stdout, // XXX
+			Store:     store,
+			Context:   msgCtx,
+			Alloc:     store.GetAllocator(),
+			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+		})
+	m.SetActivePackage(mpv)
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Wrap(fmt.Errorf("%v", r), "VM call panic: %v\n%s\n",
+				r, m.String())
+			return
+		}
+		m.Release()
+	}()
+	rtvs := m.Eval(xn)
+	fmt.Println("CPUCYCLES call", m.Cycles)
+	for i, rtv := range rtvs {
+		res = res + rtv.String()
+		if i < len(rtvs)-1 {
+			res += "\n"
+		}
+	}
+	return res, nil
+	// TODO pay for gas? TODO see context?
+}
+
+// QueryFuncs returns public facing function signatures.
+func (vm *VMKeeper) QueryFuncs(ctx sdk.Context, pkgPath string) (fsigs FunctionSignatures, err error) {
+	store := vm.getGnoStore(ctx)
+	// Ensure pkgPath is realm.
+	if !gno.IsRealmPath(pkgPath) {
+		err = ErrInvalidPkgPath(fmt.Sprintf(
+			"package is not realm: %s", pkgPath))
+		return nil, err
+	}
+	// Get Package.
+	pv := store.GetPackage(pkgPath, false)
+	if pv == nil {
+		err = ErrInvalidPkgPath(fmt.Sprintf(
+			"package not found: %s", pkgPath))
+		return nil, err
+	}
+	// Iterate over public functions.
+	pblock := pv.GetBlock(store)
+	for _, tv := range pblock.Values {
+		if tv.T.Kind() != gno.FuncKind {
+			continue // must be function
+		}
+		fv := tv.GetFunc()
+		if fv.IsMethod {
+			continue // cannot be method
+		}
+		fname := string(fv.Name)
+		first := fname[0:1]
+		if strings.ToUpper(first) != first {
+			continue // must be exposed
+		}
+		fsig := FunctionSignature{
+			FuncName: fname,
+		}
+		ft := fv.Type.(*gno.FuncType)
+		for _, param := range ft.Params {
+			pname := string(param.Name)
+			if pname == "" {
+				pname = "_"
+			}
+			ptype := gno.BaseOf(param.Type).String()
+			fsig.Params = append(fsig.Params,
+				NamedType{Name: pname, Type: ptype},
+			)
+		}
+		for _, result := range ft.Results {
+			rname := string(result.Name)
+			if rname == "" {
+				rname = "_"
+			}
+			rtype := gno.BaseOf(result.Type).String()
+			fsig.Results = append(fsig.Results,
+				NamedType{Name: rname, Type: rtype},
+			)
+		}
+		fsigs = append(fsigs, fsig)
+	}
+	return fsigs, nil
+}
+
+// QueryEval evaluates a gno expression (readonly, for ABCI queries).
+// TODO: modify query protocol to allow MsgEval.
+// TODO: then, rename to "Eval".
+func (vm *VMKeeper) QueryEval(ctx sdk.Context, pkgPath string, expr string) (res string, err error) {
+	alloc := gno.NewAllocator(maxAllocQuery)
+	store := vm.getGnoStore(ctx)
+	pkgAddr := gno.DerivePkgAddr(pkgPath)
+	// Get Package.
+	pv := store.GetPackage(pkgPath, false)
+	if pv == nil {
+		err = ErrInvalidPkgPath(fmt.Sprintf(
+			"package not found: %s", pkgPath))
+		return "", err
+	}
+	// Parse expression.
+	xx, err := gno.ParseExpr(expr)
+	if err != nil {
+		return "", err
+	}
+	// Construct new machine.
+	msgCtx := stdlibs.ExecContext{
+		ChainID:   ctx.ChainID(),
+		Height:    ctx.BlockHeight(),
+		Timestamp: ctx.BlockTime().Unix(),
+		// Msg:           msg,
+		// OrigCaller:    caller,
+		// OrigSend:      send,
+		// OrigSendSpent: nil,
+		OrigPkgAddr: pkgAddr.Bech32(),
+		Banker:      NewSDKBanker(vm, ctx), // safe as long as ctx is a fork to be discarded.
+	}
+	m := gno.NewMachineWithOptions(
+		gno.MachineOptions{
+			PkgPath:   pkgPath,
+			Output:    os.Stdout, // XXX
+			Store:     store,
+			Context:   msgCtx,
+			Alloc:     alloc,
+			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+		})
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Wrap(fmt.Errorf("%v", r), "VM query eval panic: %v\n%s\n",
+				r, m.String())
+			return
+		}
+		m.Release()
+	}()
+	rtvs := m.Eval(xx)
+	res = ""
+	for i, rtv := range rtvs {
+		res += rtv.String()
+		if i < len(rtvs)-1 {
+			res += "\n"
+		}
+	}
+	return res, nil
+}
+
+// QueryEvalString evaluates a gno expression (readonly, for ABCI queries).
+// The result is expected to be a single string (not a tuple).
+// TODO: modify query protocol to allow MsgEval.
+// TODO: then, rename to "EvalString".
+func (vm *VMKeeper) QueryEvalString(ctx sdk.Context, pkgPath string, expr string) (res string, err error) {
+	alloc := gno.NewAllocator(maxAllocQuery)
+	store := vm.getGnoStore(ctx)
+	pkgAddr := gno.DerivePkgAddr(pkgPath)
+	// Get Package.
+	pv := store.GetPackage(pkgPath, false)
+	if pv == nil {
+		err = ErrInvalidPkgPath(fmt.Sprintf(
+			"package not found: %s", pkgPath))
+		return "", err
+	}
+	// Parse expression.
+	xx, err := gno.ParseExpr(expr)
+	if err != nil {
+		return "", err
+	}
+	// Construct new machine.
+	msgCtx := stdlibs.ExecContext{
+		ChainID:   ctx.ChainID(),
+		Height:    ctx.BlockHeight(),
+		Timestamp: ctx.BlockTime().Unix(),
+		// Msg:           msg,
+		// OrigCaller:    caller,
+		// OrigSend:      jsend,
+		// OrigSendSpent: nil,
+		OrigPkgAddr: pkgAddr.Bech32(),
+		Banker:      NewSDKBanker(vm, ctx), // safe as long as ctx is a fork to be discarded.
+	}
+	m := gno.NewMachineWithOptions(
+		gno.MachineOptions{
+			PkgPath:   pkgPath,
+			Output:    os.Stdout, // XXX
+			Store:     store,
+			Context:   msgCtx,
+			Alloc:     alloc,
+			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+		})
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.Wrap(fmt.Errorf("%v", r), "VM query eval string panic: %v\n%s\n",
+				r, m.String())
+			return
+		}
+		m.Release()
+	}()
+	rtvs := m.Eval(xx)
+	if len(rtvs) != 1 {
+		return "", errors.New("expected 1 string result, got %d", len(rtvs))
+	} else if rtvs[0].T.Kind() != gno.StringKind {
+		return "", errors.New("expected 1 string result, got %v", rtvs[0].T.Kind())
+	}
+	res = rtvs[0].GetString()
+	return res, nil
+}
+
+func (vm *VMKeeper) QueryFile(ctx sdk.Context, filepath string) (res string, err error) {
+	store := vm.getGnoStore(ctx)
+	dirpath, filename := std.SplitFilepath(filepath)
+	if filename != "" {
+		memFile := store.GetMemFile(dirpath, filename)
+		if memFile == nil {
+			return "", fmt.Errorf("file %q is not available", filepath) // TODO: XSS protection
+		}
+		return memFile.Body, nil
+	} else {
+		memPkg := store.GetMemPackage(dirpath)
+		for i, memfile := range memPkg.Files {
+			if i > 0 {
+				res += "\n"
+			}
+			res += memfile.Name
+		}
+		return res, nil
+	}
+}

--- a/gnovm/pkg/vm/keeper_test.go
+++ b/gnovm/pkg/vm/keeper_test.go
@@ -1,0 +1,299 @@
+package vm
+
+// TODO: move most of the logic in ROOT/gno.land/...
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jaekwon/testify/assert"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// Sending total send amount succeeds.
+func TestVMKeeperOrigSend1(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+func init() {
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.GetOrigSend()
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run Echo function.
+	coins := std.MustParseCoins("10000000ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	res, err := env.vmk.Call(ctx, msg2)
+	assert.NoError(t, err)
+	assert.Equal(t, res, `("echo:hello world" string)`)
+	// t.Log("result:", res)
+}
+
+// Sending too much fails
+func TestVMKeeperOrigSend2(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+var admin std.Address
+
+func init() {
+     admin =	std.GetOrigCaller()
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.GetOrigSend()
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}
+
+func GetAdmin() string {
+	return admin.String()
+}
+`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run Echo function.
+	coins := std.MustParseCoins("11000000ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	res, err := env.vmk.Call(ctx, msg2)
+	assert.Error(t, err)
+	assert.Equal(t, res, "")
+	fmt.Println(err.Error())
+	assert.True(t, strings.Contains(err.Error(), "insufficient coins error"))
+}
+
+// Sending more than tx send fails.
+func TestVMKeeperOrigSend3(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+func init() {
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.Coins{{"ugnot", 10000000}}
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run Echo function.
+	coins := std.MustParseCoins("9000000ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	// XXX change this into an error and make sure error message is descriptive.
+	_, err = env.vmk.Call(ctx, msg2)
+	assert.Error(t, err)
+}
+
+// Sending realm package coins succeeds.
+func TestVMKeeperRealmSend1(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+func init() {
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.Coins{{"ugnot", 10000000}}
+	banker := std.GetBanker(std.BankerTypeRealmSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run Echo function.
+	coins := std.MustParseCoins("10000000ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	res, err := env.vmk.Call(ctx, msg2)
+	assert.NoError(t, err)
+	assert.Equal(t, res, `("echo:hello world" string)`)
+}
+
+// Sending too much realm package coins fails.
+func TestVMKeeperRealmSend2(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+func init() {
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.Coins{{"ugnot", 10000000}}
+	banker := std.GetBanker(std.BankerTypeRealmSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run Echo function.
+	coins := std.MustParseCoins("9000000ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	// XXX change this into an error and make sure error message is descriptive.
+	_, err = env.vmk.Call(ctx, msg2)
+	assert.Error(t, err)
+}
+
+// Assign admin as OrigCaller on deploying the package.
+func TestVMKeeperOrigCallerInit(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+var admin std.Address
+
+func init() {
+     admin =	std.GetOrigCaller()
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.GetOrigSend()
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}
+
+func GetAdmin() string {
+	return admin.String()
+}
+
+`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run GetAdmin()
+	coins := std.MustParseCoins("")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "GetAdmin", []string{})
+	res, err := env.vmk.Call(ctx, msg2)
+	addrString := fmt.Sprintf("(\"%s\" string)", addr.String())
+	assert.NoError(t, err)
+	assert.Equal(t, res, addrString)
+}

--- a/gnovm/pkg/vm/msgs.go
+++ b/gnovm/pkg/vm/msgs.go
@@ -1,0 +1,137 @@
+package vm
+
+import (
+	"strings"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+//----------------------------------------
+// MsgAddPackage
+
+// MsgAddPackage - create and initialize new package
+type MsgAddPackage struct {
+	Creator crypto.Address  `json:"creator" yaml:"creator"`
+	Package *std.MemPackage `json:"package" yaml:"package"`
+	Deposit std.Coins       `json:"deposit" yaml:"deposit"`
+}
+
+var _ std.Msg = MsgAddPackage{}
+
+// NewMsgAddPackage - upload a package with files.
+func NewMsgAddPackage(creator crypto.Address, pkgPath string, files []*std.MemFile) MsgAddPackage {
+	var pkgName string
+	for _, file := range files {
+		if strings.HasSuffix(file.Name, ".gno") {
+			pkgName = string(gno.PackageNameFromFileBody(file.Name, file.Body))
+			break
+		}
+	}
+	return MsgAddPackage{
+		Creator: creator,
+		Package: &std.MemPackage{
+			Name:  pkgName,
+			Path:  pkgPath,
+			Files: files,
+		},
+	}
+}
+
+// Implements Msg.
+func (msg MsgAddPackage) Route() string { return RouterKey }
+
+// Implements Msg.
+func (msg MsgAddPackage) Type() string { return "add_package" }
+
+// Implements Msg.
+func (msg MsgAddPackage) ValidateBasic() error {
+	if msg.Creator.IsZero() {
+		return std.ErrInvalidAddress("missing creator address")
+	}
+	if msg.Package.Path == "" { // XXX
+		return ErrInvalidPkgPath("missing package path")
+	}
+	if !msg.Deposit.IsValid() {
+		return std.ErrTxDecode("invalid deposit")
+	}
+	// XXX validate files.
+	return nil
+}
+
+// Implements Msg.
+func (msg MsgAddPackage) GetSignBytes() []byte {
+	return std.MustSortJSON(amino.MustMarshalJSON(msg))
+}
+
+// Implements Msg.
+func (msg MsgAddPackage) GetSigners() []crypto.Address {
+	return []crypto.Address{msg.Creator}
+}
+
+// Implements ReceiveMsg.
+func (msg MsgAddPackage) GetReceived() std.Coins {
+	return msg.Deposit
+}
+
+//----------------------------------------
+// MsgCall
+
+// MsgCall - executes a Gno statement.
+type MsgCall struct {
+	Caller  crypto.Address `json:"caller" yaml:"caller"`
+	Send    std.Coins      `json:"send" yaml:"send"`
+	PkgPath string         `json:"pkg_path" yaml:"pkg_path"`
+	Func    string         `json:"func" yaml:"func"`
+	Args    []string       `json:"args" yaml:"args"`
+}
+
+var _ std.Msg = MsgCall{}
+
+func NewMsgCall(caller crypto.Address, send sdk.Coins, pkgPath, fnc string, args []string) MsgCall {
+	return MsgCall{
+		Caller:  caller,
+		Send:    send,
+		PkgPath: pkgPath,
+		Func:    fnc,
+		Args:    args,
+	}
+}
+
+// Implements Msg.
+func (msg MsgCall) Route() string { return RouterKey }
+
+// Implements Msg.
+func (msg MsgCall) Type() string { return "exec" }
+
+// Implements Msg.
+func (msg MsgCall) ValidateBasic() error {
+	if msg.Caller.IsZero() {
+		return std.ErrInvalidAddress("missing caller address")
+	}
+	if msg.PkgPath == "" { // XXX
+		return ErrInvalidPkgPath("missing package path")
+	}
+	if msg.Func == "" { // XXX
+		return ErrInvalidExpr("missing function to call")
+	}
+	return nil
+}
+
+// Implements Msg.
+func (msg MsgCall) GetSignBytes() []byte {
+	return std.MustSortJSON(amino.MustMarshalJSON(msg))
+}
+
+// Implements Msg.
+func (msg MsgCall) GetSigners() []crypto.Address {
+	return []crypto.Address{msg.Caller}
+}
+
+// Implements ReceiveMsg.
+func (msg MsgCall) GetReceived() std.Coins {
+	return msg.Send
+}

--- a/gnovm/pkg/vm/package.go
+++ b/gnovm/pkg/vm/package.go
@@ -1,0 +1,22 @@
+package vm
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+var Package = amino.RegisterPackage(amino.NewPackage(
+	"github.com/gnolang/gno/gnovm/pkg/vm" ,
+	"vm",
+	amino.GetCallersDirname(),
+).WithDependencies(
+	std.Package,
+).WithTypes(
+	MsgCall{}, "m_call",
+	MsgAddPackage{}, "m_addpkg", // TODO rename both to MsgAddPkg?
+
+	// errors
+	InvalidPkgPathError{}, "InvalidPkgPathError",
+	InvalidStmtError{}, "InvalidStmtError",
+	InvalidExprError{}, "InvalidExprError",
+))

--- a/gnovm/pkg/vm/types.go
+++ b/gnovm/pkg/vm/types.go
@@ -1,0 +1,24 @@
+package vm
+
+import "github.com/gnolang/gno/tm2/pkg/amino"
+
+// Public facing function signatures.
+// See convertArgToGno() for supported types.
+type FunctionSignature struct {
+	FuncName string
+	Params   []NamedType
+	Results  []NamedType
+}
+
+type NamedType struct {
+	Name  string
+	Type  string
+	Value string
+}
+
+type FunctionSignatures []FunctionSignature
+
+func (fsigs FunctionSignatures) JSON() string {
+	bz := amino.MustMarshalJSON(fsigs)
+	return string(bz)
+}

--- a/gnovm/pkg/vm/vm.proto
+++ b/gnovm/pkg/vm/vm.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package vm;
+
+option go_package = "github.com/gnolang/gno/gnovm/pkg/vm/pb";
+
+// imports
+import "github.com/gnolang/gno/tm2/pkg/std/std.proto";
+
+// messages
+message m_call {
+	string Caller = 1;
+	string Send = 2;
+	string PkgPath = 3;
+	string Func = 4;
+	repeated string Args = 5;
+}
+
+message m_addpkg {
+	string Creator = 1;
+	std.MemPackage Package = 2;
+	string Deposit = 3;
+}
+
+message InvalidPkgPathError {
+}
+
+message InvalidStmtError {
+}
+
+message InvalidExprError {
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

https://github.com/gnolang/gno/issues/692

Migrate tm2/pkg/sdk/vm and pkg/crypto/keys/client parts depending on gnovm either in gnovm or gno.land

Instead of only moving the files that import files from gnovme, i moved the entire directory

Discussion:

1) Should we move tm2/cmd/tm2txsync to gnoland?
It is a tool to export and import gnoland transactions. We might not want something depends gnovm/vm in tm2.  ( if we do keep a copy of VM in TM2, it might be ok). However, it could be also a tool for tm2


2) What about misc/genproto/ ? 

